### PR TITLE
WIP: HistoryCache Feature

### DIFF
--- a/telestion-api/src/main/java/org/telestion/api/message/JsonMessage.java
+++ b/telestion-api/src/main/java/org/telestion/api/message/JsonMessage.java
@@ -2,6 +2,7 @@ package org.telestion.api.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.Handler;
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.json.JsonCodec;
 
@@ -38,6 +39,25 @@ public interface JsonMessage {
      */
     static <T extends JsonMessage> void on(Class<T> clazz, Object msgBody, Handler<T> handler){
         if(msgBody instanceof JsonObject jsonObject) {
+            if (!jsonObject.containsKey("name")) {
+                return;
+            }
+            if (clazz.getSimpleName().equals(jsonObject.getString("name"))) {
+                handler.handle(jsonObject.mapTo(clazz));
+            }
+        }
+    }
+
+    /**
+     * This method decodes a JsonMessage from the event bus.
+     *
+     * @param clazz
+     * @param msg
+     * @param handler
+     * @param <T>
+     */
+    static <T extends JsonMessage> void on(Class<T> clazz, Message<?> msg, Handler<T> handler){
+        if(msg.body() instanceof JsonObject jsonObject) {
             if (!jsonObject.containsKey("name")) {
                 return;
             }

--- a/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
+++ b/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
@@ -1,0 +1,47 @@
+package org.telestion.core.verticle;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import org.telestion.api.message.JsonMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class HistoryCache extends AbstractVerticle {
+
+    record Request(@JsonProperty String messageName, @JsonProperty int maxSize) implements JsonMessage {
+        private Request(){
+            this(null, 0);
+        }
+    }
+
+    record Response(@JsonProperty List<JsonMessage> history) implements JsonMessage {
+        private Response(){
+            this(null);
+        }
+    }
+
+    @Override
+    public void start(Promise<Void> startPromise) throws Exception {
+        var messageName = context.config().getString("messageName");
+        // every JsonMessage.nmae() has to be unique
+        // TODO put this as requirement which is asserted during runtime with an AssertionVerticle which observes the eventbus
+        var addressName = context.config().getString("addressName");
+        var historySize = context.config().getInteger("historySize");
+        vertx.eventBus().consumer(addressName, msg -> {
+           if(msg.body() instanceof JsonMessage jsonMessage && jsonMessage.name().equals(messageName)){
+               //TODO store data ...
+           }
+        });
+        vertx.eventBus().consumer(HistoryCache.class.getSimpleName(), msg -> {
+            if(msg.body() instanceof Request req && req.messageName().equals(messageName)){
+                var maxSze = req.maxSize();
+                var response = new ArrayList<JsonMessage>();
+                //TODO fill list ...
+                msg.reply(new Response(response));
+            }
+        });
+        startPromise.complete();
+    }
+}

--- a/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
+++ b/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
@@ -15,9 +15,9 @@ import java.util.stream.IntStream;
  * <p>
  *  You have to configure the following options:
  * <ul>
- *  <li>messageName - is the name of the message type (eg. Position.class.getSimpleName()).</li>
- *  <li>addressName - is the address to which the message is send.</li>
- *  <li>historySize - is the maximum size of the history</li>
+ *  <li>messageName - the name of the message type (e.g., <code>Position.class.getSimpleName()</code>)</li>
+ *  <li>addressName - the address to which the message is send</li>
+ *  <li>historySize - the maximum size of the history</li>
  * </ul>
  * </p>
  * <p>

--- a/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
+++ b/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
@@ -55,8 +55,8 @@ public final class HistoryCache extends AbstractVerticle {
         /**
          *
          * @param messageType the type of the requested message
-         * @param maxSize the maximum number of elements in the response. Only the number of elements in the history will be
-         *                returned if this is higher than the number of elements in the history. This are at most the number
+         * @param maxSize the maximum number of elements in the response. If the number of elements is higher than the number of elements in the history,
+         *                only the number of elements in the history will be returned. This is, at most, the number
          *                of elements specified in the HistoryCache configuration.
          */
         public Request(Class<? extends JsonMessage> messageType, int maxSize){

--- a/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
+++ b/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
@@ -65,7 +65,7 @@ public final class HistoryCache extends AbstractVerticle {
     }
 
     /**
-     * The response containing a list of the last received messages.
+     * The response containing a list of the latest received messages.
      * @param history the history
      */
     public record Response(@JsonProperty List<? extends JsonMessage> history) implements JsonMessage {

--- a/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
+++ b/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
@@ -45,7 +45,7 @@ public final class HistoryCache extends AbstractVerticle {
      * @param maxSize the maximum number of elements in the response. Only the number of elements in the history will be
      *                returned if this is higher than the number of elements in the history. At most, this is the number
      *                of elements are specified in the HistoryCache configuration.
-     * @param messageName the name of the messages which should be returned (eg. Position.class.getSimpleName()).
+     * @param messageName the name of the message which should be returned (e.g., <code>Position.class.getSimpleName()</code>).
      */
     public record Request(@JsonProperty String messageName, @JsonProperty int maxSize) implements JsonMessage {
         private Request(){

--- a/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
+++ b/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
@@ -25,7 +25,7 @@ import java.util.stream.IntStream;
  *  The last elements will be returned in a {@link Response} message.
  * </p>
  * <p>
- *  A simple example looks like this:
+ *  An example looks like this:
  * <pre>
  * {@code
  *   vertx.eventBus().request(HistoryCache.class.getSimpleName(), new Request(Position.class, 10), msgResult -> {

--- a/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
+++ b/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
@@ -21,7 +21,7 @@ import java.util.stream.IntStream;
  * </ul>
  * </p>
  * <p>
- *  To fetch the last elements you have to send a {@link Request} to <code>HistoryCache.class.getSimpleName()</code>.
+ *  To fetch the last elements, you have to send a {@link Request} to <code>HistoryCache.class.getSimpleName()</code>.
  *  The last elements will be returned in a {@link Response} message.
  * </p>
  * <p>

--- a/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
+++ b/telestion-core/src/main/java/org/telestion/core/verticle/HistoryCache.java
@@ -43,8 +43,8 @@ public final class HistoryCache extends AbstractVerticle {
     /**
      * A request which asks for the last elements.
      * @param maxSize the maximum number of elements in the response. Only the number of elements in the history will be
-     *                returned if this is higher than the number of elements in the history. This are at most the number
-     *                of elements specified in the HistoryCache configuration.
+     *                returned if this is higher than the number of elements in the history. At most, this is the number
+     *                of elements are specified in the HistoryCache configuration.
      * @param messageName the name of the messages which should be returned (eg. Position.class.getSimpleName()).
      */
     public record Request(@JsonProperty String messageName, @JsonProperty int maxSize) implements JsonMessage {

--- a/telestion-core/src/main/java/org/telestion/core/verticle/PositionPublisher.java
+++ b/telestion-core/src/main/java/org/telestion/core/verticle/PositionPublisher.java
@@ -18,7 +18,7 @@ public final class PositionPublisher extends AbstractVerticle {
     @Override
     public void start(Promise<Void> startPromise) throws Exception {
         vertx.setPeriodic(Duration.ofSeconds(2).toMillis(), timerId -> {
-            vertx.eventBus().publish(Address.outgoing(this), new Position(0.3, 7.2, 8.0));
+            vertx.eventBus().publish(Address.outgoing(this), new Position(0.3, 7.2, 8.0).json());
         });
         startPromise.complete();
     }

--- a/telestion-core/src/test/java/org/telestion/core/verticle/HistoryCacheTest.java
+++ b/telestion-core/src/test/java/org/telestion/core/verticle/HistoryCacheTest.java
@@ -31,7 +31,7 @@ public class HistoryCacheTest {
         var apiAddr = HistoryCache.class.getSimpleName();
         var request = new HistoryCache.Request(Position.class, 5);
 
-        vertx.eventBus().registerDefaultCodec(JsonMessage.class, JsonMessageCodec.Instance);
+        vertx.eventBus().registerDefaultCodec(JsonMessage.class, JsonMessageCodec.instance(JsonMessage.class));
         //vertx.eventBus().registerDefaultCodec(HistoryCache.Response.class, JsonMessageCodec.Instance(HistoryCache.Response.class));
         DeploymentOptions options = new DeploymentOptions()
             .setConfig(new JsonObject()

--- a/telestion-core/src/test/java/org/telestion/core/verticle/HistoryCacheTest.java
+++ b/telestion-core/src/test/java/org/telestion/core/verticle/HistoryCacheTest.java
@@ -1,0 +1,63 @@
+package org.telestion.core.verticle;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.telestion.api.message.JsonMessage;
+import org.telestion.core.message.JsonMessageCodec;
+import org.telestion.core.message.Position;
+import org.telestion.core.message.Positions;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@ExtendWith(VertxExtension.class)
+public class HistoryCacheTest {
+
+    @Test
+    void testPublish1(Vertx vertx, VertxTestContext testContext) throws Throwable {
+
+        var address = "addr1";
+        var expected = new Position(0.2, 0.1, 7.3);
+        var messageName = Position.class.getSimpleName();
+        var historySize = 20;
+        var apiAddr = HistoryCache.class.getSimpleName();
+        var request = new HistoryCache.Request(Position.class, 5);
+
+        vertx.eventBus().registerDefaultCodec(JsonMessage.class, JsonMessageCodec.Instance);
+        //vertx.eventBus().registerDefaultCodec(HistoryCache.Response.class, JsonMessageCodec.Instance(HistoryCache.Response.class));
+        DeploymentOptions options = new DeploymentOptions()
+            .setConfig(new JsonObject()
+                    .put("messageName", messageName)
+                    .put("addressName", address)
+                    .put("historySize", historySize)
+            );
+
+        //start test case
+        vertx.deployVerticle(HistoryCache.class.getName(), options, event -> {
+            Assertions.assertTrue(event.succeeded());
+            vertx.eventBus().publish(address, expected);
+            vertx.eventBus().request(apiAddr, request, responseResult -> {
+                Assertions.assertTrue(responseResult.succeeded());
+                if(responseResult.result().body() instanceof HistoryCache.Response response){
+                    var positions = response.as(Position.class);
+                    assertThat(positions, contains(expected));
+                }
+                testContext.completeNow();
+            });
+        });
+
+        assertThat(testContext.awaitCompletion(5, TimeUnit.SECONDS), is(true));
+        if (testContext.failed()) {
+            throw testContext.causeOfFailure();
+        }
+    }
+
+}


### PR DESCRIPTION
I started implementing a generic history cache which caches the last `n` JsonMessages of a certain kind. It replaces the proto database in its functionality. It is build in a way that we can span multiple instances to distribute the load. I think it is a nice example how to use Vert.x and shows the full potential of it. Notice the if statement with the enhanced instanceof and connected && 😄 