### PR TITLE
Connection API rework

### DIFF
--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/EventbusTcpBridge.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/EventbusTcpBridge.java
@@ -1,6 +1,7 @@
 package de.wuespace.telestion.services.connection;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.config.Config;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServerOptions;
@@ -9,11 +10,11 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.StaticHandler;
 import io.vertx.ext.web.handler.sockjs.SockJSBridgeOptions;
 import io.vertx.ext.web.handler.sockjs.SockJSHandler;
-import java.util.Collections;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import de.wuespace.telestion.api.config.Config;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * EventbusTcpBridge is a verticle which uses SockJS-WebSockets to extend the vertx.eventBus() to an HTTP-Server.
@@ -146,7 +147,7 @@ public final class EventbusTcpBridge extends AbstractVerticle {
 	 * @param inboundPermitted  permitted eventbus addresses for inbound connections
 	 * @param outboundPermitted permitted eventbus addresses for outbound connections
 	 */
-	@SuppressWarnings({ "unused" })
+	@SuppressWarnings({ "preview", "unused" })
 	private static record Configuration(@JsonProperty String host, @JsonProperty int port,
 			@JsonProperty List<String> inboundPermitted, @JsonProperty List<String> outboundPermitted) {
 		private Configuration() {

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/SerialConn.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/SerialConn.java
@@ -15,6 +15,7 @@ import de.wuespace.telestion.api.config.Config;
 import de.wuespace.telestion.api.message.JsonMessage;
 import com.fazecast.jSerialComm.*;
 
+@Deprecated(since = "v0.1.3", forRemoval = true)
 public final class SerialConn extends AbstractVerticle {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SerialConn.class);

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/SerialData.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/SerialData.java
@@ -3,6 +3,7 @@ package de.wuespace.telestion.services.connection;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import de.wuespace.telestion.api.message.JsonMessage;
 
+@Deprecated(since = "v0.1.3", forRemoval = true)
 public record SerialData(@JsonProperty byte[] data) implements JsonMessage {
 
 	@SuppressWarnings("unused")

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/TcpConn.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/TcpConn.java
@@ -22,6 +22,7 @@ import de.wuespace.telestion.services.message.Address;
  * published on the event bus. Incoming messages are published to the event bus too. The connection listens to the event
  * bus and send incoming messages over tcp to the participant. All addresses are defined in the configuration.
  */
+@Deprecated(since = "v0.1.3", forRemoval = true)
 public final class TcpConn extends AbstractVerticle {
 
 	private static final Logger logger = LoggerFactory.getLogger(TcpConn.class);

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/TcpConn.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/TcpConn.java
@@ -1,6 +1,8 @@
 package de.wuespace.telestion.services.connection;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -8,13 +10,10 @@ import io.vertx.core.Promise;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.net.*;
-import java.util.Collections;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import de.wuespace.telestion.api.message.JsonMessage;
-import de.wuespace.telestion.api.config.Config;
-import de.wuespace.telestion.services.message.Address;
+
+import java.util.List;
 
 /**
  * This class opens a tcp connection. This could either be a tcp client to a host or a host which accepts new clients.
@@ -162,7 +161,7 @@ public final class TcpConn extends AbstractVerticle {
 	 * A chunk of data which is transmitted with the {@link TcpConn}.
 	 *
 	 * @param participant the participant of the tcp connection which has send this chunk of data or should receive it
-	 * @param datathe     actual data
+	 * @param data the     actual data
 	 */
 		public static record Data(@JsonProperty Participant participant, @JsonProperty byte[] data) implements JsonMessage {
 
@@ -202,8 +201,7 @@ public final class TcpConn extends AbstractVerticle {
 			@JsonProperty List<String> consumingAddresses) {
 		@SuppressWarnings("unused")
 		private Configuration() {
-			this(null, 7777, Address.outgoing(TcpConn.class), null,
-					Collections.singletonList(Address.incoming(TcpConn.class)));
+			this(null, 7777, null, null, null);
 		}
 	}
 }

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/ConnectionData.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/ConnectionData.java
@@ -1,0 +1,32 @@
+package de.wuespace.telestion.services.connection.rework;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.JsonMessage;
+
+/**
+ * <p>
+ *     Data-Object for sending received data from incoming connections over the
+ *     {@link io.vertx.core.eventbus.EventBus EventBus}.<br>
+ *     Apart from containing the raw data from the stream, also
+ *     connection-details are contained, which (if needed) allow for connection-specific operations, e.g. for sending
+ *     responses to the sender.
+ * </p>
+ * <p>
+ *     IncomingData-objects will only be checked by the parsers which might be added to the
+ *     {@link io.vertx.core.eventbus.EventBus EventBus}. To send them to specific parsers, the output-address of the
+ *     receiver-verticles must be equivalent to the incoming-addresses of the parser-verticles.
+ * </p>
+ *
+ * @param rawData from the stream
+ * @param conDetails from the header which might be important to the handlers
+ *
+ * @author Cedric Boes
+ * @version 1.0
+ */
+public record ConnectionData(@JsonProperty byte[] rawData,
+							 @JsonProperty ConnectionDetails conDetails) implements JsonMessage {
+
+	private ConnectionData() {
+		this(null, null);
+	}
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/ConnectionDetails.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/ConnectionDetails.java
@@ -1,0 +1,9 @@
+package de.wuespace.telestion.services.connection.rework;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import de.wuespace.telestion.api.message.JsonMessage;
+
+@JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, property="className")
+public interface ConnectionDetails extends JsonMessage {
+
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/RawMessage.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/RawMessage.java
@@ -1,0 +1,11 @@
+package de.wuespace.telestion.services.connection.rework;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.JsonMessage;
+
+public record RawMessage(@JsonProperty byte[] data) implements JsonMessage {
+	@SuppressWarnings("unused")
+	private RawMessage() {
+		this(null);
+	}
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/Receiver.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/Receiver.java
@@ -1,0 +1,68 @@
+package de.wuespace.telestion.services.connection.rework;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
+
+public final class Receiver extends AbstractVerticle {
+
+	@Override
+	public void start(Promise<Void> startPromise) {
+		config = Config.get(config, config(), Configuration.class);
+
+		for (var con : config.connectionAddresses()) {
+			vertx.eventBus().consumer(con,
+					raw -> JsonMessage.on(ConnectionData.class, raw,
+							msg -> {
+								logger.debug("Connection-Message received on {}", con);
+								vertx.eventBus().publish(config.outputAddr(), msg.json());
+							}));
+		}
+		startPromise.complete();
+	}
+
+	@Override
+	public void stop(Promise<Void> stopPromise) {
+		stopPromise.complete();
+	}
+
+	/**
+	 * @param outputAddr
+	 * @param connectionAddresses
+	 */
+	public record Configuration(
+			@JsonProperty String outputAddr,
+			@JsonProperty String... connectionAddresses) {
+
+		private Configuration() {
+			this(null);
+		}
+	}
+
+	public Receiver() {
+		this(null);
+	}
+
+	/**
+	 *
+	 * @param config {@link Configuration} for the creation
+	 */
+	public Receiver(Configuration config) {
+		this.config = config;
+	}
+
+	/**
+	 *
+	 */
+	private Configuration config;
+
+	/**
+	 *
+	 */
+	private static final Logger logger = LoggerFactory.getLogger(Receiver.class);
+
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/Sender.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/Sender.java
@@ -1,0 +1,75 @@
+package de.wuespace.telestion.services.connection.rework;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class Sender extends AbstractVerticle {
+
+	@Override
+	public void stop(Promise<Void> stopPromise) {
+		config = Config.get(config, config(), Configuration.class);
+		stopPromise.complete();
+	}
+
+	@Override
+	public void start(Promise<Void> startPromise) {
+		vertx.eventBus().consumer(config.inputAddress,
+				raw -> {
+					JsonMessage.on(SenderData.class, raw, this::handleMessage);
+					JsonMessage.on(ConnectionData.class, raw, msg -> handleMessage(SenderData.fromConnectionData(msg)));
+				});
+		startPromise.complete();
+	}
+
+	/**
+	 * @param inputAddress
+	 * @param connectionAddresses
+	 */
+	public record Configuration(
+			@JsonProperty String inputAddress,
+			@JsonProperty String... connectionAddresses) implements JsonMessage {
+
+		@SuppressWarnings("unused")
+		private Configuration() {
+			this(null);
+		}
+	}
+
+	public Sender() {
+		this(null);
+	}
+
+	/**
+	 *
+	 * @param config {@link Configuration} for the creation
+	 */
+	public Sender(Configuration config) {
+		this.config = config;
+	}
+
+	/**
+	 *
+	 * @param msg to send
+	 */
+	private void handleMessage(SenderData msg) {
+		for (var s : config.connectionAddresses()) {
+			logger.debug("Sending Message to {}", s);
+			vertx.eventBus().publish(s, msg.json());
+		}
+	}
+
+	/**
+	 *
+	 */
+	private Configuration config;
+
+	/**
+	 *
+	 */
+	private static final Logger logger = LoggerFactory.getLogger(Sender.class);
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/SenderData.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/SenderData.java
@@ -1,0 +1,44 @@
+package de.wuespace.telestion.services.connection.rework;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.JsonMessage;
+
+/**
+ * <p>
+ *     Data-Object for the data which must be sent over a network-connection.<br>
+ *     Apart from containing the raw data from the stream, also
+ *     connection-details are contained, which allow to determine the target where to send the data to.
+ * </p>
+ * <p>
+ *     The {@link Sender Sender-verticle} will be handling the distribution of the data.
+ *     If invalid though the message will not be sent at all and the sending verticle will not be notified, this will
+ *     only be logged as an error.
+ * </p>
+ * <p>
+ *     Sending this type of object to a specific sender means that {@link ConnectionDetails} for other senders are
+ *     treated as invalid and will be logged as an error.
+ * </p>
+ *
+ * @param rawData		to send
+ * @param conDetails	array of connection-details - each element represents one connection where the data will be
+ *                      sent to
+ *
+ * @author Cedric Boes
+ * @version 1.0
+ */
+public record SenderData(@JsonProperty byte[] rawData,
+						 @JsonProperty ConnectionDetails... conDetails) implements JsonMessage {
+
+	@SuppressWarnings("unused")
+	private SenderData() {
+		this(null);
+	}
+
+	/**
+	 *
+	 * @param data
+	 */
+	public static SenderData fromConnectionData(ConnectionData data) {
+		return new SenderData(data.rawData(), data.conDetails());
+	}
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/StaticSender.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/StaticSender.java
@@ -1,0 +1,53 @@
+package de.wuespace.telestion.services.connection.rework;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StaticSender extends AbstractVerticle {
+
+	@Override
+	public void start(Promise<Void> startPromise) {
+		config = Config.get(config, config(), Configuration.class);
+
+		vertx.eventBus().consumer(config.inAddress(), raw -> {
+			JsonMessage.on(RawMessage.class, raw, msg -> {
+				logger.debug("Sending static message");
+				vertx.eventBus().publish(config.outAddress(), new ConnectionData(msg.data(),
+						config.staticDetails()).json());
+			});
+		});
+
+		startPromise.complete();
+	}
+
+	@Override
+	public void stop(Promise<Void> stopPromise) {
+		stopPromise.complete();
+	}
+
+	public record Configuration(@JsonProperty String inAddress,
+								@JsonProperty String outAddress,
+								@JsonProperty ConnectionDetails staticDetails) implements JsonMessage {
+
+		@SuppressWarnings("unused")
+		private Configuration() {
+			this(null, null, null);
+		}
+	}
+
+	public StaticSender() {
+		this(null);
+	}
+
+	public StaticSender(Configuration config) {
+		this.config = config;
+	}
+
+	private Configuration config;
+	private final static Logger logger = LoggerFactory.getLogger(StaticSender.class);
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/Tuple.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/Tuple.java
@@ -1,0 +1,29 @@
+package de.wuespace.telestion.services.connection.rework;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A simple implementation of a Value-Pair whose values are linked together without any key - value relationship.
+ *
+ * @param <T1>	Type 1
+ * @param <T2>	Type 2
+ *
+ * @param value1	Value of Type 1
+ * @param value2	Value of Type 2
+ *
+ * @author Cedric Boes
+ * @version 1.0
+ */
+public record Tuple<T1, T2>(
+		@JsonProperty T1 value1,
+		@JsonProperty T2 value2) {
+
+	/**
+	 * This is only for reflection of Config-Loading!
+	 */
+	@SuppressWarnings("unused")
+	private Tuple() {
+		this(null, null);
+	}
+
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/serial/SerialConn.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/serial/SerialConn.java
@@ -1,0 +1,101 @@
+package de.wuespace.telestion.services.connection.rework.serial;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fazecast.jSerialComm.SerialPort;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
+import de.wuespace.telestion.services.connection.rework.ConnectionData;
+import de.wuespace.telestion.services.connection.rework.SenderData;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * @author Cedric Boes, Jan v. Pichowski
+ * @version 2.0
+ */
+public final class SerialConn extends AbstractVerticle {
+
+	@Override
+	public void start(Promise<Void> startPromise) {
+		config = Config.get(config, config(), Configuration.class);
+
+		logger.info("Opening Connection on {}", config.serialPort());
+
+		serialPort = SerialPort.getCommPort(config.serialPort());
+		serialPort.openPort();
+
+		// In
+		vertx.setPeriodic(config.sampleTime(), event -> {
+			try {
+				var inpStream = serialPort.getInputStream();
+				var len = inpStream.available();
+				if (len > 0) {
+					logger.debug("Reading available bytes");
+					var data = inpStream.readNBytes(len);
+					vertx.eventBus().publish(config.outAddress(),
+							new ConnectionData(data, new SerialDetails(config.serialPort())).json());
+				}
+			} catch(IOException e) {
+				logger.error("A critical error occurred while checking for new incoming data", e);
+			}
+		});
+
+		// Out
+		vertx.eventBus().consumer(config.inAddress(), raw -> JsonMessage.on(SenderData.class, raw,
+				msg -> Arrays.stream(msg.conDetails())
+						.filter(det -> det instanceof SerialDetails)
+						.map(det -> (SerialDetails) det)
+						.forEach(det -> {
+							if (det.serialPort().equals(config.serialPort())) {
+								logger.debug("Sending bytes");
+								serialPort.writeBytes(msg.rawData(), msg.rawData().length);
+							}
+						})
+		));
+
+		startPromise.complete();
+	}
+
+	@Override
+	public void stop(Promise<Void> stopPromise) {
+		logger.info("Closing Connection on {}", config.serialPort());
+		if (serialPort.isOpen()) {
+			serialPort.closePort();
+		} else {
+			logger.warn("Connection on {} could not be closed because it was not open", config.serialPort());
+		}
+		stopPromise.complete();
+	}
+
+	public record Configuration(@JsonProperty String inAddress,
+								@JsonProperty String outAddress,
+								@JsonProperty String serialPort,
+								@JsonProperty long sampleTime) implements JsonMessage {
+		@SuppressWarnings("unused")
+		private Configuration() {
+			this(null, null, null, 0L);
+		}
+
+		public Configuration(String inAddress, String outAddress, String serialPort) {
+			this(inAddress, outAddress, serialPort, 100);
+		}
+	}
+
+	public SerialConn() {
+		this(null);
+	}
+
+	public SerialConn(Configuration config) {
+		this.config = config;
+	}
+
+	private Configuration config;
+	private SerialPort serialPort;
+
+	private static final Logger logger = LoggerFactory.getLogger(SerialConn.class);
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/serial/SerialDetails.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/serial/SerialDetails.java
@@ -1,0 +1,21 @@
+package de.wuespace.telestion.services.connection.rework.serial;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.services.connection.rework.ConnectionDetails;
+
+/**
+ *
+ * @param serialPort
+ *
+ * @author Cedric Boes
+ * @version 1.0
+ */
+public record SerialDetails(@JsonProperty String serialPort) implements ConnectionDetails {
+	/**
+	 * For json-messages.
+	 */
+	@SuppressWarnings("unused")
+	private SerialDetails() {
+		this(null);
+	}
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpClient.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpClient.java
@@ -1,0 +1,146 @@
+package de.wuespace.telestion.services.connection.rework.tcp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
+import de.wuespace.telestion.services.connection.rework.ConnectionData;
+import de.wuespace.telestion.services.connection.rework.Tuple;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.core.net.NetSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class TcpClient extends AbstractVerticle {
+
+	@Override
+	public void start(Promise<Void> startPromise) {
+		config = Config.get(config, config(), Configuration.class);
+
+		var options = new NetClientOptions();
+		options.setIdleTimeout(config.timeout() == TcpTimeouts.NO_RESPONSES
+				? (int) TcpTimeouts.NO_TIMEOUT : (int) config.timeout());
+		currentClient = vertx.createNetClient(options);
+
+		activeClients = new HashMap<>();
+
+		vertx.eventBus().consumer(config.inAddress(), raw -> {
+			if (!JsonMessage.on(TcpData.class, raw, this::handleDispatchedMsg)) {
+				JsonMessage.on(ConnectionData.class, raw, this::handleMsg);
+			}
+		});
+
+		startPromise.complete();
+	}
+
+	@Override
+	public void stop(Promise<Void> stopPromise) {
+		stopPromise.complete();
+	}
+
+	public record Configuration(@JsonProperty String inAddress,
+								@JsonProperty String outAddress,
+								@JsonProperty long timeout) implements JsonMessage {
+		/**
+		 * For json
+		 */
+		@SuppressWarnings("unused")
+		private Configuration() {
+			this(null, null, 0L);
+		}
+	}
+
+	public TcpClient() {
+		this(null);
+	}
+
+	public TcpClient(Configuration config) {
+		this.config = config;
+	}
+
+	private void handleDispatchedMsg(TcpData tcpData) {
+		var details = tcpData.details();
+
+		// Checks if socket already exists, if not connects to Server and if successful sends data asynchronously
+		vertx.executeBlocking(handler -> {
+			if (!activeClients.containsKey(new Tuple<>(details.ip(), details.port()))) {
+				currentClient.connect(details.port(), details.ip(), h -> {
+					if (h.succeeded()) {
+						onConnected(h.result());
+						handler.complete();
+					} else {
+						logger.error("Failed to create new NetClient with {}:{}:", details.ip(), details.port(),
+								h.cause());
+						handler.fail(h.cause());
+					}
+				});
+			} else {
+				handler.complete();
+			}
+		}, handler -> {
+			if (handler.succeeded()) {
+				logger.debug("Sending data to {}:{}", details.ip(), details.port());
+				activeClients.get(new Tuple<>(details.ip(), details.port())).write(Buffer.buffer(tcpData.data()));
+			} else {
+				logger.warn("Due to an error the packet to {}:{} will be dropped", details.ip(), details.port());
+			}
+		});
+	}
+
+	/**
+	 * Called when a new socket is opened.
+	 *
+	 * @param socket the newly connected socket
+	 */
+	private void onConnected(NetSocket socket) {
+		var ip = socket.remoteAddress().host();
+		var port = socket.remoteAddress().port();
+		var key = new Tuple<>(ip, port);
+
+		activeClients.put(key, socket);
+
+		logger.info("Connection established ({}:{})", ip, port);
+
+		var packetIdCounter = new AtomicInteger(0);
+
+		socket.handler(buffer -> {
+			var packetId = packetIdCounter.getAndIncrement();
+			logger.debug("New message received from Server ({}:{}, packetId={})", ip, port, packetId);
+			vertx.eventBus().publish(config.outAddress(), new ConnectionData(buffer.getBytes(), new TcpDetails(ip, port,
+					packetId)).json());
+		});
+
+		socket.exceptionHandler(error -> {
+			logger.error("Encountered an unexpected error (Server: {}:{})", ip, port,
+					error);
+			activeClients.remove(key);
+		});
+
+		socket.closeHandler(handler -> {
+			logger.info("Closing remote connection with Server ({}:{})", ip, port);
+			activeClients.remove(key);
+		});
+	}
+
+	private void handleMsg(ConnectionData data) {
+		var details = data.conDetails();
+		if (details instanceof TcpDetails tcpDet) {
+			handleDispatchedMsg(new TcpData(data.rawData(), tcpDet));
+		} else {	// Shouldn't happen due to Dispatcher
+			logger.warn("Wrong connection detail type received. Packet will be dropped.");
+			// If there will be ever a logger for broken packets, send this
+		}
+	}
+
+	private Configuration config;
+	private HashMap<Tuple<String, Integer>, NetSocket> activeClients;
+	private NetClient currentClient;
+
+	private static final Logger logger = LoggerFactory.getLogger(TcpClient.class);
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpData.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpData.java
@@ -1,0 +1,16 @@
+package de.wuespace.telestion.services.connection.rework.tcp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.JsonMessage;
+
+public record TcpData(@JsonProperty byte[] data,
+					  @JsonProperty TcpDetails details) implements JsonMessage {
+
+	/**
+	 * For reflection
+	 */
+	@SuppressWarnings("unused")
+	private TcpData() {
+		this(null, null);
+	}
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpDetails.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpDetails.java
@@ -1,0 +1,21 @@
+package de.wuespace.telestion.services.connection.rework.tcp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.services.connection.rework.ConnectionDetails;
+
+public record TcpDetails(@JsonProperty String ip,
+						 @JsonProperty int port,
+						 @JsonProperty int packetId) implements ConnectionDetails {
+
+	/**
+	 * For reflection
+	 */
+	@SuppressWarnings("unused")
+	private TcpDetails() {
+		this(null, 0, 0);
+	}
+
+	public TcpDetails(String ip, int port) {
+		this(ip, port, 0);
+	}
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpDispatcher.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpDispatcher.java
@@ -1,0 +1,74 @@
+package de.wuespace.telestion.services.connection.rework.tcp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
+import de.wuespace.telestion.services.connection.rework.ConnectionData;
+import de.wuespace.telestion.services.connection.rework.SenderData;
+import de.wuespace.telestion.services.connection.rework.Tuple;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+
+import java.util.Arrays;
+
+public class TcpDispatcher extends AbstractVerticle {
+
+	@Override
+	public void start(Promise<Void> startPromise) {
+		config = Config.get(config, config(), Configuration.class);
+
+		vertx.eventBus().consumer(config.inAddress(), raw -> {
+			if (!JsonMessage.on(SenderData.class, raw, msg -> Arrays.stream(msg.conDetails())
+					.filter(det -> det instanceof TcpDetails)
+					.map(det -> (TcpDetails) det)
+					.forEach(det -> handle(msg.rawData(), det)))) {
+				JsonMessage.on(ConnectionData.class, raw, msg -> {
+					if (msg.conDetails() instanceof TcpDetails det) {
+						handle(msg.rawData(), det);
+					}
+				});
+			}
+		});
+		startPromise.complete();
+	}
+
+	@Override
+	public void stop(Promise<Void> stopPromise) {
+		stopPromise.complete();
+	}
+
+	public record Configuration(@JsonProperty String inAddress,
+								@JsonProperty String outAddress) implements JsonMessage {
+		/**
+		 * For config
+		 */
+		@SuppressWarnings("unused")
+		private Configuration() {
+			this(null, null);
+		}
+	}
+
+	public TcpDispatcher(TcpServer... servers) {
+		this(null, servers);
+	}
+
+	public TcpDispatcher(Configuration config, TcpServer... servers) {
+		this.config = config;
+		this.servers = servers;
+	}
+
+	private void handle(byte[] bytes, TcpDetails details) {
+		for (var server : servers) {
+			if (server.isActiveCon(new Tuple<>(details.ip(), details.port()))) {
+				vertx.eventBus().publish(server.getConfig().inAddress(),
+						new TcpData(bytes, details).json());
+			} else {
+				vertx.eventBus().publish(config.outAddress(),
+						new TcpData(bytes, details).json());
+			}
+		}
+	}
+
+	private Configuration config;
+	private final TcpServer[] servers;
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpServer.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpServer.java
@@ -1,0 +1,216 @@
+package de.wuespace.telestion.services.connection.rework.tcp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.config.Config;
+import de.wuespace.telestion.api.message.JsonMessage;
+import de.wuespace.telestion.services.connection.rework.ConnectionData;
+import de.wuespace.telestion.services.connection.rework.Tuple;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.core.net.NetSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * <b>An implementation of an unencrypted TCP-Server.</b>
+ * <p>
+ *     Features are:
+ *     <ul>
+ *         <li>Opening new connections to TCP-Clients</li>
+ *         <li>Receiving data from all the open connections</li>
+ *         <li>Keep the connections open until either no package gets sent for a certain amount of time (timeout) or
+ *         the Client closes the connection</li>
+ *         <li>Sending answers back to the Client if the connections are still open</li>
+ *     </ul>
+ * </p>
+ */
+public final class TcpServer extends AbstractVerticle {
+
+	@Override
+	public void start(Promise<Void> startPromise) throws Exception {
+		config = Config.get(config, config(), Configuration.class);
+
+		// Unencrypted -> TODO: Implement functionality for encryption
+		var serverOptions = new NetServerOptions();
+		serverOptions.setHost(config.hostAddress());
+		serverOptions.setPort(config.port());
+		serverOptions.setIdleTimeout(config.clientTimeout() == TcpTimeouts.NO_RESPONSES
+				? (int) TcpTimeouts.NO_TIMEOUT : (int) config.clientTimeout());
+		serverOptions.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+		activeCons = new HashMap<>();
+
+		server = vertx.createNetServer(serverOptions);
+		server.connectHandler(this::onConnected);
+		server.exceptionHandler(handler -> logger.error("Encountered an unexpected error (Config: {})", config.json(),
+				handler));
+		server.listen(h -> complete(h, startPromise,
+				r -> logger.info("Successfully started. Running on {}:{}", config.hostAddress(), r.actualPort())));
+
+		vertx.eventBus().consumer(config.inAddress, raw -> {
+			if (!JsonMessage.on(TcpData.class, raw, this::handleDispatchedMsg)) {
+				JsonMessage.on(ConnectionData.class, raw, this::handleMsg);
+			}
+		});
+
+		startPromise.complete();
+	}
+
+	@Override
+	public void stop(Promise<Void> stopPromise) throws Exception {
+		if (server != null) {
+			activeCons.values().forEach(net -> net.close(stopPromise));
+			logger.info("Closing Server on {}:{}", config.hostAddress(), config.port());
+			server.close();
+		}
+		stopPromise.complete();
+	}
+
+	/**
+	 * Configuration for this Verticle which can be loaded from a config.<br>
+	 * An optional timeout can be specified which is the consecutive time without any packets incoming or outgoing after
+	 * which a client will be disconnected. Special timeouts can be found in {@link TcpTimeouts}.
+	 *
+	 * @param inAddress		address on which the verticle listens on
+	 * @param outAddress	address on which the verticle publishes
+	 * @param hostAddress	host-address on which the Server-Socket should run
+	 * @param port			port on which the Server-Socket should run
+	 * @param clientTimeout time until timeout
+	 */
+	public record Configuration(@JsonProperty String inAddress,
+								@JsonProperty String outAddress,
+								@JsonProperty String hostAddress,
+								@JsonProperty int port,
+								@JsonProperty long clientTimeout) implements JsonMessage {
+
+		/**
+		 * Used for reflection.
+		 */
+		@SuppressWarnings("unused")
+		private Configuration() {
+			this(null, null, null, 0, 0L);
+		}
+
+		public Configuration(String inAddress, String outAddress, String hostAddress, int port) {
+			this(inAddress, outAddress, hostAddress, port, TcpTimeouts.DEFAULT_TIMEOUT);
+		}
+	}
+
+	public TcpServer() {
+		this(null);
+	}
+
+	public TcpServer(Configuration config) {
+		if (config != null && (config.hostAddress() == null || config.hostAddress().equals(""))) {
+			config = new Configuration(config.inAddress(), config.outAddress(), "localhost", config.port(),
+					config.clientTimeout());
+		}
+		this.config = config;
+	}
+
+	public Configuration getConfig() {
+		return this.config;
+	}
+
+	// Public for own Dispatcher implementations
+	public boolean isActiveCon(Tuple<String, Integer> key) {
+		return activeCons.containsKey(key);
+	}
+
+	// @jvpichowski this is similar to TcpClient#onConnected, do you want to put this into one method?
+	private void onConnected(NetSocket netSocket) {
+		var ip = netSocket.remoteAddress().hostAddress();
+		var port = netSocket.remoteAddress().port();
+		var key = new Tuple<>(ip, port);
+
+		logger.info("Connection established with {}:{}", ip, port);
+		activeCons.put(key, netSocket);
+
+		var packetIdCounter = new AtomicInteger(0);
+
+		netSocket.handler(buffer -> {
+			var packetId = packetIdCounter.getAndIncrement();
+			logger.debug("New message received from Client ({}:{}, packetId={})", ip, port, packetId);
+			vertx.eventBus().publish(config.outAddress(), new ConnectionData(buffer.getBytes(), new TcpDetails(ip, port,
+					packetId)).json());
+			if (config.clientTimeout() == TcpTimeouts.NO_RESPONSES) {
+				netSocket.close();
+			}
+		});
+
+		netSocket.exceptionHandler(error -> {
+			logger.error("Encountered an unexpected error (Client: {}:{})", ip, port,
+					error);
+			activeCons.remove(key);
+		});
+
+		netSocket.closeHandler(handler -> {
+			logger.info("Closing remote connection with {}:{}", ip, port);
+			activeCons.remove(key);
+		});
+	}
+
+	/**
+	 * Completes a promise based on the success of a {@link AsyncResult}. If it was successful a handler will be called.
+	 *
+	 * @param result  the result which is observed
+	 * @param promise the promise which will be completed
+	 * @param handler the handler which will be executed on a successful result
+	 * @param <T>     the type of the result
+	 */
+	private static <T> void complete(AsyncResult<T> result, Promise<?> promise, Handler<T> handler) {
+		if (result.failed()) {
+			promise.fail(result.cause());
+			return;
+		}
+		handler.handle(result.result());
+		promise.tryComplete();
+	}
+
+	private void handleDispatchedMsg(TcpData data) {
+		var details = data.details();
+
+		var element = activeCons.get(new Tuple<>(details.ip(), details.port()));
+
+		// Might be useful to send this to the TCP-Client however the config must be varied for this (future update?)
+		if (element == null) {
+			logger.warn("Requested connection {}:{} is (no longer) available. Packet will be dropped.",
+					data.details().ip(), data.details().port());
+			return;
+		}
+
+		logger.debug("Sending message to {}:{}", details.ip(), details.port());
+
+		if (element.writeQueueFull()) {
+			logger.error("Write queue of socket is full ({}:{}). Packet will be dropped.", details.ip(),
+					details.port());
+			return;
+		}
+
+		element.write(Buffer.buffer(data.data()));
+	}
+
+	private void handleMsg(ConnectionData data) {
+		var details = data.conDetails();
+		if (details instanceof TcpDetails tcpDet) {
+			handleDispatchedMsg(new TcpData(data.rawData(), tcpDet));
+		} else {	// Shouldn't happen due to Dispatcher
+			logger.warn("Wrong connection detail type received. Packet will be dropped.");
+			// If there will be ever a logger for broken packets, send this
+		}
+	}
+
+	private Configuration config;
+	private NetServer server;
+	private HashMap<Tuple<String, Integer>, NetSocket> activeCons;
+
+	private static final Logger logger = LoggerFactory.getLogger(TcpServer.class);
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpTimeouts.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/tcp/TcpTimeouts.java
@@ -1,0 +1,9 @@
+package de.wuespace.telestion.services.connection.rework.tcp;
+
+import java.time.Duration;
+
+public class TcpTimeouts {
+	public static final long NO_RESPONSES = -1;		// Close tcp connection after first received packet
+	public static final long NO_TIMEOUT = 0;		// Never actively close active tcp connection
+	public static final long DEFAULT_TIMEOUT = Duration.ofSeconds(30).toMillis();	// 30 secs.
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/udp/UdpConn.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/udp/UdpConn.java
@@ -1,0 +1,7 @@
+package de.wuespace.telestion.services.connection.rework.udp;
+
+public class UdpConn {
+	public UdpConn() {
+		throw new RuntimeException("Not implemented, yet!");
+	}
+}

--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/udp/UdpDetails.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/udp/UdpDetails.java
@@ -1,0 +1,12 @@
+package de.wuespace.telestion.services.connection.rework.udp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.services.connection.rework.ConnectionDetails;
+
+public record UdpDetails(@JsonProperty String ip,
+						 @JsonProperty int port,
+						 @JsonProperty int packetId) implements ConnectionDetails {
+	private UdpDetails() {
+		this(null, 0, 0);
+	}
+}

--- a/modules/telestion-services/src/test/java/de/wuespace/telestion/services/connection/ConnApiTest.java
+++ b/modules/telestion-services/src/test/java/de/wuespace/telestion/services/connection/ConnApiTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +63,9 @@ public class ConnApiTest {
 				testContext.failNow(result.cause());
 			}
 		});
+
+		// Because GitHub actions run... weird
+		Thread.sleep(Duration.ofSeconds(1).toMillis());
 
 		// Publish Test data on bus
 		logger.info("Sending Test-Data");
@@ -129,6 +133,9 @@ public class ConnApiTest {
 			}
 		});
 
+		// Because GitHub actions run... weird
+		Thread.sleep(Duration.ofSeconds(1).toMillis());
+
 		// Publish Test data on bus
 		logger.info("Sending Test-Data");
 		IntStream.range(0, PACKAGE_COUNT)
@@ -183,6 +190,9 @@ public class ConnApiTest {
 			}
 		});
 
+		// Because GitHub actions run... weird
+		Thread.sleep(Duration.ofSeconds(1).toMillis());
+
 		// Publish test-data
 		logger.info("Sending packages to StaticSender with receiverNumber {}", staticDetails.receiverNumber());
 		IntStream.range(0, PACKAGE_COUNT).forEach(i -> {
@@ -200,6 +210,7 @@ public class ConnApiTest {
 
 	@Test
 	void testRealUse(Vertx vertx, VertxTestContext testContext) throws Throwable {
+		// Not implemented, yet, so nothing should fail here
 		testContext.completeNow();
 
 		if (testContext.failed()) {

--- a/modules/telestion-services/src/test/java/de/wuespace/telestion/services/connection/ConnApiTest.java
+++ b/modules/telestion-services/src/test/java/de/wuespace/telestion/services/connection/ConnApiTest.java
@@ -1,0 +1,221 @@
+package de.wuespace.telestion.services.connection;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.JsonMessage;
+import de.wuespace.telestion.services.connection.rework.*;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith(VertxExtension.class)
+public class ConnApiTest {
+
+	@Test
+	void testReceiver(Vertx vertx, VertxTestContext testContext) throws Throwable {
+		// Create test-data and constants
+		var RECEIVER_COUNT = 10;
+		var bytes = new byte[] {'T', 'E', 'S', 'T'};
+
+		// Create various dummy Receiver-Addresses
+		var addresses = IntStream.range(0, RECEIVER_COUNT).mapToObj(i -> "ReceiverInput" + i).toArray(String[]::new);
+
+		// Output-Address for Receiver-Api
+		var outputAddress = "ReceiverApiPublish";
+
+		// Create listener for Api
+		var queue = new ConcurrentLinkedQueue<Integer>();
+		vertx.eventBus().consumer(outputAddress, raw -> JsonMessage.on(ConnectionData.class, raw, msg -> {
+			if (msg.conDetails() instanceof TestConnDetails testDetails) {
+				logger.info("Received data from {}", testDetails.receiverNumber());
+				assertThat(msg.rawData(), is(bytes));
+				queue.add(testDetails.receiverNumber());
+				Supplier<Stream<Integer>> supplier = () -> queue.stream().distinct();
+				if (supplier.get().allMatch(i -> i >= 0 && i <= RECEIVER_COUNT)
+						&& supplier.get().toArray().length == RECEIVER_COUNT) {
+					testContext.completeNow();
+				}
+			} else {
+				logger.warn("Although this is a special Test-Case, other information were sent to the "
+						+ "receiver-api");
+			}
+		}));
+
+		// Create and deploy Receiver verticle (mustn't fail!)
+		var receiver = new Receiver(new Receiver.Configuration(outputAddress, addresses));
+		vertx.deployVerticle(receiver, result -> {
+			if (result.failed()) {
+				testContext.failNow(result.cause());
+			}
+		});
+
+		// Publish Test data on bus
+		logger.info("Sending Test-Data");
+		IntStream.range(0, RECEIVER_COUNT).forEach(i -> vertx.eventBus().publish(addresses[i],
+				new ConnectionData(bytes, new TestConnDetails(i)).json()));
+		logger.info("All Test-Data sent");
+
+		// Wait for completion
+		assertThat(testContext.awaitCompletion(5, TimeUnit.SECONDS), is(true));
+		if (testContext.failed()) {
+			throw testContext.causeOfFailure();
+		}
+	}
+
+	@Test
+	void testSender(Vertx vertx, VertxTestContext testContext) throws Throwable {
+		// Create test-data and constants
+		var SENDER_COUNT = 10;
+		var PACKAGE_COUNT = 10;
+		var bytes = new byte[] {'T', 'E', 'S', 'T'};
+
+		// Create various dummy Sender-Addresses
+		var addresses = IntStream.range(0, SENDER_COUNT).mapToObj(i -> "SenderIncoming" + i).toArray(String[]::new);
+
+		// Addresses for Sender-Api
+		var inputAddress = "senderApiInput";
+
+		// Create Listeners
+		var queue = new ConcurrentLinkedQueue<Integer>();
+		Arrays.stream(addresses).forEach(addr -> vertx.eventBus().consumer(addr,
+				raw -> JsonMessage.on(SenderData.class, raw, msg -> {
+					for (var detail : msg.conDetails()) {
+						if (detail instanceof TestConnDetails testDetails) {
+							// Not the most beautiful implementation :(
+							if (testDetails.receiverNumber() != Integer.parseInt(addr.replace("SenderIncoming", ""))) {
+								continue;
+							}
+							logger.info("Received package to {}", testDetails.receiverNumber());
+							assertThat(msg.rawData(), is(bytes));
+							queue.add(testDetails.receiverNumber());
+							if (queue.stream().distinct().allMatch(i -> i >= 0 && i <= SENDER_COUNT)) {
+								var length = queue.toArray().length;
+								var requestedLength = SENDER_COUNT*PACKAGE_COUNT;
+								if (length > requestedLength) {
+									testContext.failNow("Too many messages received");
+								}
+								if (length == requestedLength) {
+									testContext.completeNow();
+								}
+							} else {
+								testContext.failNow("Data from unknown sender received in test-case");
+							}
+						} else {
+							logger.warn("Although this is a special Test-Case, other information were sent to the "
+									+ "sender-api");
+						}
+					}
+				})));
+
+		// Create and deploy Receiver verticle (mustn't fail!)
+		var sender = new Sender(new Sender.Configuration(inputAddress, addresses));
+		vertx.deployVerticle(sender, result -> {
+			if (result.failed()) {
+				testContext.failNow(result.cause());
+			}
+		});
+
+		// Publish Test data on bus
+		logger.info("Sending Test-Data");
+		IntStream.range(0, PACKAGE_COUNT)
+				.forEach(i -> vertx.eventBus().publish(inputAddress,
+						new SenderData(bytes,
+								IntStream.range(0, SENDER_COUNT).mapToObj(TestConnDetails::new)
+										.toArray(TestConnDetails[]::new)).json()));
+		logger.info("All Test-Data sent");
+
+		// Wait for completion
+		assertThat(testContext.awaitCompletion(5, TimeUnit.SECONDS), is(true));
+		if (testContext.failed()) {
+			throw testContext.causeOfFailure();
+		}
+	}
+
+	@Test
+	void testStaticSender(Vertx vertx, VertxTestContext testContext) throws Throwable {
+		// Define some useful constants
+		var PACKAGE_COUNT = 10;
+		var bytes = new byte[] {'T', 'E', 'S', 'T'};
+		var staticDetails = new TestConnDetails(42);
+
+		// Create dummy-connection and test-evaluator
+		var counter = new AtomicInteger(0);
+		vertx.eventBus().consumer("StaticSenderPublish", raw -> {
+			JsonMessage.on(ConnectionData.class, raw, msg -> {
+				try {
+					assertThat(msg.rawData(), is(bytes));
+					assertThat(msg.conDetails(), is(staticDetails));
+					logger.info("Received package no. {}", counter.incrementAndGet());
+					if (counter.get() == PACKAGE_COUNT) {
+						testContext.completeNow();
+					} else if (counter.get() > PACKAGE_COUNT) {
+						testContext.failNow("Too many packages received on the dummy test-sender");
+					}
+				} catch(Throwable e) {
+					testContext.failNow(e);
+					logger.error("An exception occurred while testing StaticSender", e);
+				}
+			});
+		});
+
+		// Create Static-Sender
+		var staticSender = new StaticSender(new StaticSender.Configuration(
+				"StaticSenderIn", "StaticSenderPublish", staticDetails));
+
+		// Deployment of tested verticle mustn't fail!
+		vertx.deployVerticle(staticSender, handler -> {
+			if (handler.failed()) {
+				testContext.failNow(handler.cause());
+			}
+		});
+
+		// Publish test-data
+		logger.info("Sending packages to StaticSender with receiverNumber {}", staticDetails.receiverNumber());
+		IntStream.range(0, PACKAGE_COUNT).forEach(i -> {
+			logger.info("Sending package {} to StaticSender", i);
+			vertx.eventBus().publish("StaticSenderIn", new RawMessage(bytes).json());
+		});
+		logger.info("All packages for StaticSender sent");
+
+		// Wait for completion
+		assertThat(testContext.awaitCompletion(5, TimeUnit.SECONDS), is(true));
+		if (testContext.failed()) {
+			throw testContext.causeOfFailure();
+		}
+	}
+
+	@Test
+	void testRealUse(Vertx vertx, VertxTestContext testContext) throws Throwable {
+		testContext.completeNow();
+
+		if (testContext.failed()) {
+			throw testContext.causeOfFailure();
+		}
+	}
+
+	private record TestConnDetails(@JsonProperty int receiverNumber) implements ConnectionDetails {
+		/**
+		 * For parsing Json
+		 */
+		@SuppressWarnings("unused")
+		private TestConnDetails() {
+			this(-1);
+		}
+	}
+
+	private final Logger logger = LoggerFactory.getLogger(ConnApiTest.class);
+}

--- a/modules/telestion-services/src/test/java/de/wuespace/telestion/services/connection/TcpConnTest.java
+++ b/modules/telestion-services/src/test/java/de/wuespace/telestion/services/connection/TcpConnTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import de.wuespace.telestion.api.message.JsonMessage;
 
+@Deprecated(since = "v0.1.3", forRemoval = true)
 @ExtendWith(VertxExtension.class)
 public class TcpConnTest {
 


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

feat: connection-api rework

### Details <!-- Describe the content of the pull request -->

The old connection api had the simple problem of creating way too much boilerplate-code for each new connection-implementation. On top of this, the receiving verticles needed to write network-specific code which in general was not ideal.
To focus this issue I created a rework of the current system which is both modular and highly customizable. What do I mean with this? The new system allows "normal" data collecting telemetry verticles to always get the raw data from the stream without caring about the network interface itself. It can also answer to the same location quite easily if the network controller allows for that. Apart from that there is still the possibility to write network specific code, so that no functionality gets lost.

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

[Connection API_210315_125100.pdf](https://github.com/wuespace/telestion-core/files/6411582/Connection.API_210315_125100.pdf)

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
