### PR TITLE
feat!: Baud Rate Configuration for `de.wuespace.telestion.services.connection.rework.serial.SerialConn`

### DIFF
--- a/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/serial/SerialConn.java
+++ b/modules/telestion-services/src/main/java/de/wuespace/telestion/services/connection/rework/serial/SerialConn.java
@@ -15,8 +15,8 @@ import java.io.IOException;
 import java.util.Arrays;
 
 /**
- * @author Cedric Boes, Jan v. Pichowski
- * @version 2.0
+ * @author Cedric Boes, Jan v. Pichowski, Pablo Klaschka
+ * @version 3.0
  */
 public final class SerialConn extends AbstractVerticle {
 
@@ -28,6 +28,10 @@ public final class SerialConn extends AbstractVerticle {
 
 		serialPort = SerialPort.getCommPort(config.serialPort());
 		serialPort.openPort();
+		if (!serialPort.setBaudRate(config.baudRate())) {
+			logger.error("The selected baud rate of " + config.baudRate() + " is not supported on this platform.");
+		}
+		// TODO: Add more feature-rich implementation using serialPort.setComPortParameters()
 
 		// In
 		vertx.setPeriodic(config.sampleTime(), event -> {
@@ -75,14 +79,15 @@ public final class SerialConn extends AbstractVerticle {
 	public record Configuration(@JsonProperty String inAddress,
 								@JsonProperty String outAddress,
 								@JsonProperty String serialPort,
+								@JsonProperty int baudRate,
 								@JsonProperty long sampleTime) implements JsonMessage {
 		@SuppressWarnings("unused")
 		private Configuration() {
-			this(null, null, null, 0L);
+			this(null, null, null, 9600, 0L);
 		}
 
 		public Configuration(String inAddress, String outAddress, String serialPort) {
-			this(inAddress, outAddress, serialPort, 100);
+			this(inAddress, outAddress, serialPort, 9600, 100);
 		}
 	}
 


### PR DESCRIPTION
This is required for the Daedalus 2 project, where we need a baud rate other than `9600` (the default rate used automatically before this change).