### PR TITLE
feat(api): Delete redundant class parameter from `Config.get()` when using with default config

### DIFF
--- a/modules/telestion-api/build.gradle
+++ b/modules/telestion-api/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '6.6'
 
     implementation "io.vertx:vertx-core:4.2.1"
+    implementation "io.vertx:vertx-rx-java2:4.2.1"
 }
 
 test {

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/config/Config.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/config/Config.java
@@ -30,11 +30,12 @@ public final class Config {
 	 * @param defaultConfig this config contains the default values which replace absent values in the JSON config
 	 * @param jsonConfig    this is common config which represents the config class in json. If fields are not available
 	 *                      they will be set like the default values of the class when the default constructor is called.
-	 * @param type          the type of the config.
 	 * @param <T>           defines the class type of the configuration
 	 * @return the selected configuration
 	 */
-	public static <T> T get(T forcedConfig, T defaultConfig, JsonObject jsonConfig, Class<T> type) {
+	@SuppressWarnings("unchecked")
+	public static <T> T get(T forcedConfig, T defaultConfig, JsonObject jsonConfig) {
+		var type = (Class<T>) defaultConfig.getClass();
 		var config = JsonObject.mapFrom(defaultConfig).mergeIn(jsonConfig);
 		return forcedConfig == null ? config.mapTo(type) : forcedConfig;
 	}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/config/Config.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/config/Config.java
@@ -1,5 +1,6 @@
 package de.wuespace.telestion.api.config;
 
+import io.reactivex.annotations.NonNull;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -27,14 +28,15 @@ public final class Config {
 	 * Selects the right configuration file.
 	 *
 	 * @param forcedConfig  this config will be applied if it is not null
-	 * @param defaultConfig this config contains the default values which replace absent values in the JSON config
+	 * @param defaultConfig this config contains the default values which replace absent values in the JSON config;
+	 *                      it must not be <code>null</code>!
 	 * @param jsonConfig    this is common config which represents the config class in json. If fields are not available
 	 *                      they will be set like the default values of the class when the default constructor is called.
 	 * @param <T>           defines the class type of the configuration
 	 * @return the selected configuration
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> T get(T forcedConfig, T defaultConfig, JsonObject jsonConfig) {
+	public static <T> T get(T forcedConfig, @NonNull T defaultConfig, JsonObject jsonConfig) {
 		var type = (Class<T>) defaultConfig.getClass();
 		var config = JsonObject.mapFrom(defaultConfig).mergeIn(jsonConfig);
 		return forcedConfig == null ? config.mapTo(type) : forcedConfig;

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/config/Config.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/config/Config.java
@@ -6,7 +6,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * A utility class for the selection of configuration files.
  *
- * @author Jan von Pichowski
+ * @author Jan von Pichowski, Cedric Boes
  */
 public final class Config {
 
@@ -27,16 +27,35 @@ public final class Config {
 	/**
 	 * Selects the right configuration file.
 	 *
-	 * @param forcedConfig  this config will be applied if it is not null
+	 * @param forcedConfig	this config will be applied if it is not null
+	 * @param defaultConfig this config contains the default values which replace absent values in the JSON config
+	 * @param jsonConfig	this is common config which represents the config class in json. If fields are not available
+	 *                     	they will be set like the default values of the class when the default constructor is
+	 *                     	called
+	 * @param type       	the type of the config.
+	 * @param <T>          	defines the class type of the configuration
+	 * @return the selected configuration
+	 */
+	public static <T> T get(T forcedConfig, T defaultConfig, JsonObject jsonConfig, Class<T> type) {
+		var config = JsonObject.mapFrom(defaultConfig).mergeIn(jsonConfig);
+		return forcedConfig == null ? config.mapTo(type) : forcedConfig;
+	}
+
+	/**
+	 * Selects the right configuration file without the class object like
+	 * {@link #get(Object, Object, JsonObject, Class)}.
+	 *
+	 * @param forcedConfig	this config will be applied if it is not null
 	 * @param defaultConfig this config contains the default values which replace absent values in the JSON config;
 	 *                      it must not be <code>null</code>!
 	 * @param jsonConfig    this is common config which represents the config class in json. If fields are not available
-	 *                      they will be set like the default values of the class when the default constructor is called.
+	 *                      they will be set like the default values of the class when the default constructor is
+	 *                      called.
 	 * @param <T>           defines the class type of the configuration
 	 * @return the selected configuration
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> T get(T forcedConfig, @NonNull T defaultConfig, JsonObject jsonConfig) {
+	public static <T> T getUnsafe(T forcedConfig, @NonNull T defaultConfig, JsonObject jsonConfig) {
 		var type = (Class<T>) defaultConfig.getClass();
 		var config = JsonObject.mapFrom(defaultConfig).mergeIn(jsonConfig);
 		return forcedConfig == null ? config.mapTo(type) : forcedConfig;


### PR DESCRIPTION
### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
