### PR TITLE
Header Information

### DIFF
--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/config/Config.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/config/Config.java
@@ -5,7 +5,7 @@ import io.vertx.core.json.JsonObject;
 /**
  * A utility class for the selection of configuration files.
  *
- * @author Jan von Pichowski
+ * @author Jan von Pichowski (@jvpichowski)
  * @deprecated replaced by {@link de.wuespace.telestion.api.verticle.TelestionVerticle}
  */
 @Deprecated(since = "0.6.0", forRemoval = true)

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/Information.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/Information.java
@@ -1,0 +1,164 @@
+package de.wuespace.telestion.api.header;
+
+import de.wuespace.telestion.api.header.serialization.NoSerializationException;
+import de.wuespace.telestion.api.header.serialization.SerializationUtils;
+import de.wuespace.telestion.api.utils.NoSuchPrimitiveTypeException;
+import io.vertx.core.MultiMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.RecordComponent;
+import java.util.*;
+
+/**
+ * The base class for all information records for header metadata information.
+ *
+ * @author Cedric Boes (@cb0s), Ludwig Richter (@fussel178), Pablo Klaschka (@pklaschka)
+ */
+public interface Information {
+	/**
+	 * Appends all record information to the Vert.x message headers based on the serialization information
+	 * on each record component.
+	 * <p>
+	 * If a record value is {@code null}, the default value from serialization information is used instead.
+	 * <p>
+	 * If a record component has no serialization information it is skipped on packing and a warning gets logged.
+	 *
+	 * @param headers existing Vert.x message headers to place the packed record information on
+	 * @return the given headers with the packed record information
+	 */
+	default MultiMap appendToHeaders(MultiMap headers) {
+		if (!this.getClass().isRecord()) {
+			logger.error("%s is not a record. Please use a record as information type to use header utility functions."
+					.formatted(this.getClass().getName()));
+			return headers;
+		}
+
+		for (var component : this.getClass().getRecordComponents()) {
+			try {
+				var serialization = SerializationUtils.serialize(component);
+				var value = getOrDefault(component);
+				headers.set(serialization.name(), InformationCodec.encode(value));
+			} catch (NoSerializationException e) {
+				logger.warn(e.getMessage(), e);
+			} catch (IllegalAccessException | InvocationTargetException e) {
+				logger.error("An unexpected exception occurred. Cannot access record value {} in {}. " +
+								"Please file a bug report at https://github.com/wuespace/telestion-core/issues/new",
+						component.getName(), this.getClass().getName(), e);
+			}
+		}
+
+		return headers;
+	}
+
+	/**
+	 * Like {@link #appendToHeaders(MultiMap)} but uses new and empty headers instead.
+	 *
+	 * @return new headers only with the packed record information
+	 */
+	default MultiMap toHeaders() {
+		return appendToHeaders(MultiMap.caseInsensitiveMultiMap());
+	}
+
+	/**
+	 * Extracts record information from Vert.x message headers based on the serialization information
+	 * on each record component.
+	 * <p>
+	 * If a record value is {@code null}, the default value from serialization information is used instead.
+	 *
+	 * @param headers          Vert.x message headers containing the required information
+	 *                         to construct an information record
+	 * @param informationClass the type of the information record
+	 * @return the constructed information record or {@code null} if no value
+	 * for a non-nullable record component is found
+	 */
+	static <T> T fromHeaders(MultiMap headers, Class<T> informationClass) {
+		if (!informationClass.isRecord()) {
+			logger.error("%s is not a record. Please use a record as information type to use header utility functions."
+					.formatted(informationClass.getName()));
+			return null;
+		}
+
+		var values = new ArrayList<>();
+
+		for (var component : informationClass.getRecordComponents()) {
+			try {
+				var serialization = SerializationUtils.serialize(component);
+				var defaultValue = SerializationUtils.nullableDefaultValue(serialization);
+				var value = headers.get(serialization.name());
+				value = Objects.isNull(value) ? defaultValue : value;
+
+				if (Objects.isNull(value)) {
+					if (!serialization.isNullable()) {
+						logger.error("No value for record component {} found, but is explicitly required.",
+								component.getName());
+						return null;
+					}
+					values.add(InformationCodec.getDefault(component.getType()));
+					continue;
+				}
+
+				values.add(serialization.isUnsigned()
+						? InformationCodec.decodeUnsigned(value, component.getType())
+						: InformationCodec.decode(value, component.getType()));
+			} catch (NoSerializationException | NoSuchPrimitiveTypeException e) {
+				logger.warn(e.getMessage(), e);
+				values.add(null);
+			}
+		}
+
+		return constructFromAttributes(values.toArray(), informationClass);
+	}
+
+	/**
+	 * Returns the value of a record component or if {@code null} the default value
+	 * from the serialization information is used instead.
+	 *
+	 * @param component the record component with a value and serialization information
+	 * @return the value or the default value of the record component
+	 * @throws InvocationTargetException when the value of the record component cannot be accessed
+	 * @throws IllegalAccessException    when the value of the record component cannot be accessed
+	 * @throws NoSerializationException  when the record component has no serialization information
+	 */
+	default Object getOrDefault(RecordComponent component)
+			throws InvocationTargetException, IllegalAccessException, NoSerializationException {
+		var defaultValue = SerializationUtils.nullableDefaultValue(component);
+		var value = component.getAccessor().invoke(this);
+		return Objects.isNull(value) ? defaultValue : value;
+	}
+
+	/**
+	 * Constructs a new information record from a type and value map. The information type is given.
+	 * <p>
+	 * If not all type and value entries available to successfully construct the given information type,
+	 * it returns {@code null} and logs an error message to the backend.
+	 *
+	 * @param values           the values of the information record in same order as record components
+	 * @param informationClass the information type to should be generated
+	 * @return the generated information record
+	 */
+	static <T> T constructFromAttributes(Object[] values,
+										 Class<T> informationClass) {
+
+		var classes = Arrays.stream(informationClass.getRecordComponents())
+				.map(RecordComponent::getType)
+				.toArray(Class<?>[]::new);
+
+		try {
+			return informationClass.getConstructor(classes).newInstance(values);
+		} catch (InstantiationException
+				| IllegalAccessException
+				| IllegalArgumentException
+				| InvocationTargetException
+				| NoSuchMethodException e) {
+			logger.error("An unexpected exception occurred. " +
+							"Cannot construct {} from parsed header information (Classes: {}, Values: {}). " +
+							"Please file a bug report at https://github.com/wuespace/telestion-core/issues/new",
+					informationClass.getName(), Arrays.toString(classes), Arrays.toString(values), e);
+			return null;
+		}
+	}
+
+	Logger logger = LoggerFactory.getLogger(Information.class);
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/InformationCodec.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/InformationCodec.java
@@ -1,0 +1,29 @@
+package de.wuespace.telestion.api.header;
+
+import de.wuespace.telestion.api.utils.AbstractUtils;
+import de.wuespace.telestion.api.utils.NoSuchPrimitiveTypeException;
+import de.wuespace.telestion.api.utils.PrimitiveTypeParser;
+
+import java.util.Objects;
+
+/**
+ * @author Ludwig Richter, Cedric Boes
+ */
+public class InformationCodec extends AbstractUtils {
+	public static String encode(Object value) {
+		if (Objects.isNull(value)) return null;
+		return String.valueOf(value);
+	}
+
+	public static <T> T decode(String encoded, Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
+		return PrimitiveTypeParser.parse(encoded, primitiveClass);
+	}
+
+	public static <T> T decodeUnsigned(String encoded, Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
+		return PrimitiveTypeParser.parseUnsigned(encoded, primitiveClass);
+	}
+
+	public static <T> T getDefault(Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
+		return PrimitiveTypeParser.getDefault(primitiveClass);
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/InformationUtils.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/InformationUtils.java
@@ -1,0 +1,36 @@
+package de.wuespace.telestion.api.header;
+
+import de.wuespace.telestion.api.utils.AbstractUtils;
+import io.vertx.core.MultiMap;
+
+import java.util.Arrays;
+
+/**
+ * Utility class for conveniently adding {@link Information} to a {@link MultiMap header}.
+ *
+ * @author Cedric Boes (@cb0s), Ludwig Richter (@fussel178)
+ */
+public class InformationUtils extends AbstractUtils {
+	/**
+	 * Appends all given {@link Information information objects} to the given {@link MultiMap}.
+	 *
+	 * @param headers     multi map to append to
+	 * @param information {@link Information information-objects} which should be added to the given {@link MultiMap}
+	 * @return given {@link MultiMap} headers with appended information
+	 */
+	public static MultiMap appendAll(MultiMap headers, Information... information) {
+		Arrays.stream(information).forEach(e -> e.appendToHeaders(headers));
+		return headers;
+	}
+
+	/**
+	 * Creates a new {@link MultiMap} which is filled with the given {@link Information}.
+	 * The new map is then being returned.
+	 *
+	 * @param information {@link Information information-array} to add to the header
+	 * @return new {@link MultiMap} header with the given information-array as content.
+	 */
+	public static MultiMap allToHeaders(Information... information) {
+		return appendAll(MultiMap.caseInsensitiveMultiMap(), information);
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/serialization/CommonNames.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/serialization/CommonNames.java
@@ -1,0 +1,23 @@
+package de.wuespace.telestion.api.header.serialization;
+
+import de.wuespace.telestion.api.utils.AbstractUtils;
+
+public class CommonNames extends AbstractUtils {
+	// serial stuff
+	public static final String SERIAL_DEVICE = "serial-device";
+	public static final String SERIAL_BAUDRATE = "serial-baudrate";
+	// ip stuff
+	public static final String HOST_IP = "host-ip";
+	public static final String HOST_NAME = "host-name";
+	public static final String HOST_PORT = "host-port";
+	// message stuff
+	public static final String MESSAGE_ID = "message-id";
+	public static final String MESSAGE_NAME = "message-name";
+	public static final String MESSAGE_TYPE = "message-type";
+	// time stuff
+	public static final String TIME_CREATED = "time-created";
+	public static final String TIME_MODIFIED = "time-modified";
+	public static final String TIME_ACCESSED = "time-accessed";
+	public static final String TIME_RECEIVED = "time-received";
+	public static final String TIME_CURRENT = "time-current";
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/serialization/NoSerializationException.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/serialization/NoSerializationException.java
@@ -1,0 +1,48 @@
+package de.wuespace.telestion.api.header.serialization;
+
+import java.lang.reflect.RecordComponent;
+
+/**
+ * Thrown to indicate that the {@link de.wuespace.telestion.api.header.Information Information methods}
+ * tried to encode or decode values from or to message headers
+ * but the record component has no serialization information.
+ *
+ * If that exception occurs, please check that all record components have
+ * serialization information before continuing.
+ *
+ * @see de.wuespace.telestion.api.header.Information
+ * @author Ludwig Richter
+ */
+public class NoSerializationException extends RuntimeException {
+	private final RecordComponent component;
+
+	/**
+	 * Constructs a {@code NoSerializationException} with the record component
+	 * missing serialization information and an additional cause.
+	 * @param component the record component missing the serialization information
+	 * @param cause an additional cause
+	 */
+	public NoSerializationException(RecordComponent component, Throwable cause) {
+		super("Record component " + component.getName() + " has no Serialization Information. " +
+						"Please add Serialization information (@SerializationInfo).", cause);
+		this.component = component;
+	}
+
+	/**
+	 * Constructs a {@code NoSerializationException} with the record component
+	 * missing serialization information.
+	 * @param component the record component missing the serialization information
+	 */
+	public NoSerializationException(RecordComponent component) {
+		this(component, null);
+	}
+
+	/**
+	 * Returns the record component missing serialization information which
+	 * causes this exception to be thrown.
+	 * @return the record component missing serialization information
+	 */
+	public RecordComponent getComponent() {
+		return this.component;
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/serialization/SerializationInfo.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/serialization/SerializationInfo.java
@@ -1,0 +1,57 @@
+package de.wuespace.telestion.api.header.serialization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the record component is serializable in a Vert.x message header.
+ * It gives the {@link de.wuespace.telestion.api.header.Information Information record}
+ * additional information about its components
+ * like name in the header space or a default value in case there are no information
+ * from the message header available.
+ *
+ * @see SerializationUtils
+ * @see de.wuespace.telestion.api.header.Information
+ * @author Cedric Boes, Ludwig Richter
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.RECORD_COMPONENT)
+public @interface SerializationInfo {
+	/**
+	 * The value of {@link #defaultValue()} if no default value for the record component is given.
+	 */
+	String NO_DEFAULT_VALUE = "";
+
+	/**
+	 * The name of header space where the record component should be stored and accessed.
+	 * @return the name/key of the header space
+	 */
+	String name();
+
+	/**
+	 * The default value in case there are no information from the message header available.
+	 * This property is optional. If no default value is defined,
+	 * it falls back to {@link #NO_DEFAULT_VALUE}.
+	 * @return the default value of the record component
+	 */
+	String defaultValue() default NO_DEFAULT_VALUE;
+
+	/**
+	 * Indicates, if the primitive type should pe parsed as unsigned integer when possible.
+	 * Defaults to {@code false}.
+	 *
+	 * @see de.wuespace.telestion.api.header.InformationCodec#decodeUnsigned(String, Class)
+	 * @return {@code true} if the primitive type should pe parsed as unsigned integer when possible
+	 */
+	boolean isUnsigned() default false;
+
+	/**
+	 * Indicates, that an attribute can be set to {@code null}.
+	 * Defaults to {@code true}.
+	 *
+	 * @return {@code true} if an argument can take the {@code null}, {@code false} otherwise
+	 */
+	boolean isNullable() default true;
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/serialization/SerializationUtils.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/header/serialization/SerializationUtils.java
@@ -1,0 +1,73 @@
+package de.wuespace.telestion.api.header.serialization;
+
+import de.wuespace.telestion.api.utils.AbstractUtils;
+
+import java.lang.reflect.RecordComponent;
+
+/**
+ * <p><strong>Utilities for {@link SerializationInfo}</strong></p>
+ *
+ * <p>
+ *     It supplements {@link SerializationInfo} and adds further functionality.
+ * </p>
+ *
+ * @see SerializationInfo
+ * @see de.wuespace.telestion.api.header.Information
+ * @author Ludwig Richter
+ */
+public class SerializationUtils extends AbstractUtils {
+	/**
+	 * Returns the serialization information for the record component.
+	 * @param component the record component that should have serialization information
+	 * @return the serialization information of the record component
+	 * @throws NoSerializationException when the record component has no serialization information
+	 */
+	public static SerializationInfo serialize(RecordComponent component) throws NoSerializationException {
+		if (!component.isAnnotationPresent(SerializationInfo.class)) {
+			throw new NoSerializationException(component);
+		}
+
+		return component.getAnnotation(SerializationInfo.class);
+	}
+
+	/**
+	 * Checks if the serialization information has no default value.
+	 * @param serialization the serialization information with or without a default value
+	 * @return {@code true} if the serialization information has a default value
+	 */
+	public static boolean hasNoDefault(SerializationInfo serialization) {
+		return serialization.defaultValue().equals(SerializationInfo.NO_DEFAULT_VALUE);
+	}
+
+	/**
+	 * Like {@link #hasNoDefault(SerializationInfo)},
+	 * but extracts the serialization information from the record component.
+	 * @param component the record component that should have serialization information with or without a default value
+	 * @return {@code true} if the serialization information has a default value
+	 * @throws NoSerializationException when the record component has no serialization information
+	 */
+	public static boolean hasNoDefault(RecordComponent component) throws NoSerializationException {
+		return hasNoDefault(serialize(component));
+	}
+
+	/**
+	 * Returns the default value of the serialization information
+	 * or {@code null} when the default value is not available.
+	 * @param serialization the serialization information with or without a default value
+	 * @return the default value of the serialization information or {@code null} when not available
+	 */
+	public static String nullableDefaultValue(SerializationInfo serialization) {
+		return hasNoDefault(serialization) ? null : serialization.defaultValue();
+	}
+
+	/**
+	 * Returns the default value of the serialization information from the record component.
+	 * If the default value is not available, it returns {@code null} instead.
+	 * @param component the record component that should have serialization information with or without a default value
+	 * @return the default value of the serialization information or {@code null} when not available
+	 * @throws NoSerializationException when the record component has no serialization information
+	 */
+	public static String nullableDefaultValue(RecordComponent component) throws NoSerializationException {
+		return nullableDefaultValue(serialize(component));
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/JsonMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/JsonMessage.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  * All subclasses have to be valid json classes. This means that they could be encoded by
  * {@link io.vertx.core.spi.json.JsonCodec} which is backed by {@link io.vertx.core.json.jackson.JacksonCodec}.
  *
- * @author Jan von Pichowski, Cedric Boes
+ * @author Jan von Pichowski (@jvpichowski), Cedric Boes (@cb0s)
  * @version 1.2
  */
 public interface JsonMessage {

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/InformationCodec.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/InformationCodec.java
@@ -7,7 +7,7 @@ import de.wuespace.telestion.api.utils.PrimitiveTypeParser;
 import java.util.Objects;
 
 /**
- * @author Ludwig Richter, Cedric Boes
+ * @author Ludwig Richter (@fussel178), Cedric Boes (@cb0s)
  */
 public class InformationCodec extends AbstractUtils {
 	public static String encode(Object value) {

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/InformationCodec.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/InformationCodec.java
@@ -7,18 +7,45 @@ import de.wuespace.telestion.api.utils.PrimitiveTypeParser;
 import java.util.Objects;
 
 /**
+ * A utility class helping to encode and decode {@link Information} with the {@link PrimitiveTypeParser}.
+ *
  * @author Ludwig Richter (@fussel178), Cedric Boes (@cb0s)
  */
 public class InformationCodec extends AbstractUtils {
+	/**
+	 * Encodes a given object by calling {@link String#valueOf(Object)}. If the specified object is primitive,
+	 * the corresponding variant of {@code String.valueOf()} is called.
+	 *
+	 * @param value to get encode as a {@link String}
+	 * @return String representation of the given object
+	 */
 	public static String encode(Object value) {
 		if (Objects.isNull(value)) return null;
 		return String.valueOf(value);
 	}
 
+	/**
+	 * Decodes a given encoded {@link String} and tries to map it to a primitive datatype (or String). It is a wrapper
+	 * to the {@link PrimitiveTypeParser}.
+	 *
+	 * @param encoded			{@link String} to decode
+	 * @param primitiveClass	type to map to
+	 * @param <T>	type to decode to
+	 * @return	decoded primitive type from the given {@link String}
+	 * @throws NoSuchPrimitiveTypeException if decoding fails
+	 */
 	public static <T> T decode(String encoded, Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
 		return PrimitiveTypeParser.parse(encoded, primitiveClass);
 	}
 
+	/**
+	 * Like {@link #decode(String, Class)} but decoded result is unsigned.
+	 *
+	 * @param encoded        the encoded/raw value as string
+	 * @param primitiveClass the class of the primitive type to try to parse to
+	 * @param <T>            class representation of the primitive type
+	 * @throws NoSuchPrimitiveTypeException if decoding fails
+	 */
 	public static <T> T decodeUnsigned(String encoded, Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
 		return PrimitiveTypeParser.parseUnsigned(encoded, primitiveClass);
 	}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/package-info.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/package-info.java
@@ -6,7 +6,7 @@
  * Headers can be used in different scenarios. They are usually used to provide more details to a message which are not
  * part of the message itself. This can be a hint to where it belongs to or timestamps or even where it is supposed to
  * go in the end.<br/>
- * An example can be found in the connection api in the {@link de.wuespace.telestion.services.connection} module.<br/>
+ * An example can be found in the connection api in the {@code de.wuespace.telestion.services.connection} module.<br/>
  * The classes of this package are used to add support for Java-15 Records for headers.
  * <h3>Usage</h3>
  * Headers are extending
@@ -26,7 +26,7 @@
  * proposals for names can be found in {@link de.wuespace.telestion.api.message.header.serialization.CommonNames}.<br/>
  * Those proposals are not mandatory but highly recommended.
  * <h3>Examples</h3>
- * To see how to use this api, refer to the examples from {@link de.wuespace.telestion.example}, namely
+ * To see how to use this api, refer to the examples from {@code de.wuespace.telestion.example}, namely
  * {@code InformationSender} and {@code InformationReceiver} which show how to send and receive headers.
  * <p>
  * (c) WueSpace e.V.

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/serialization/CommonNames.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/serialization/CommonNames.java
@@ -14,20 +14,61 @@ import de.wuespace.telestion.api.utils.AbstractUtils;
  */
 public class CommonNames extends AbstractUtils {
 	// serial stuff
+	/**
+	 * Recommended name to specify the serial device.
+	 */
 	public static final String SERIAL_DEVICE = "serial-device";
+	/**
+	 * Recommended name to specify the serial baudrate.
+	 */
 	public static final String SERIAL_BAUDRATE = "serial-baudrate";
 	// ip stuff
+	/**
+	 * Recommended name to specify the ip address in the ip protocol.
+	 */
 	public static final String HOST_IP = "host-ip";
+	/**
+	 * Recommended name to specify the host name in the ip protocol.
+	 */
 	public static final String HOST_NAME = "host-name";
+	/**
+	 * Recommended name to specify the port of the host in the ip protocol.
+	 */
 	public static final String HOST_PORT = "host-port";
 	// message stuff
+	/**
+	 * Recommended name for some type of message id in the header.
+	 */
 	public static final String MESSAGE_ID = "message-id";
+	/**
+	 * Recommended name for some type of message name in the header.
+	 */
 	public static final String MESSAGE_NAME = "message-name";
+	/**
+	 * Recommended name for the type of message.
+	 */
 	public static final String MESSAGE_TYPE = "message-type";
 	// time stuff
+	/**
+	 * Recommended name for when the package got created.
+	 */
 	public static final String TIME_CREATED = "time-created";
+	/**
+	 * Recommended name for when a package was last modified.
+	 */
 	public static final String TIME_MODIFIED = "time-modified";
+	/**
+	 * Recommended name for when a package was last accessed.
+	 */
 	public static final String TIME_ACCESSED = "time-accessed";
+	/**
+	 * Recommended name for when a package was received.
+	 */
 	public static final String TIME_RECEIVED = "time-received";
+	/**
+	 * Recommended name for communicating the current time to another verticle.
+	 */
 	public static final String TIME_CURRENT = "time-current";
+
+	// This list is incomplete and will be extended in the future
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/serialization/NoSerializationException.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/serialization/NoSerializationException.java
@@ -13,7 +13,7 @@ import java.lang.reflect.RecordComponent;
  * serialization information before continuing.
  *
  * @see Information
- * @author Ludwig Richter
+ * @author Ludwig Richter (@fussel178)
  */
 public class NoSerializationException extends RuntimeException {
 	private final RecordComponent component;

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/serialization/SerializationInfo.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/serialization/SerializationInfo.java
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
  *
  * @see SerializationUtils
  * @see Information
- * @author Cedric Boes, Ludwig Richter
+ * @author Cedric Boes (@cb0s), Ludwig Richter (@fussel178)
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.RECORD_COMPONENT)

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/serialization/SerializationUtils.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/header/serialization/SerializationUtils.java
@@ -14,7 +14,7 @@ import java.lang.reflect.RecordComponent;
  *
  * @see SerializationInfo
  * @see Information
- * @author Ludwig Richter
+ * @author Ludwig Richter (@fussel178)
  */
 public class SerializationUtils extends AbstractUtils {
 	/**

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/package-info.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/package-info.java
@@ -2,7 +2,7 @@
  * <h2>Telestion API</h2>
  *
  * This module contains different core features/functionalities which are used to implement
- * {@link de.wuespace.telestion.services Telestion-Services}.
+ * {@code de.wuespace.telestion.services}.
  * <p>
  * Refer to the links below to explore our core-features which are mandatory for every telestion-service.
  * <p>

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/AbstractUtils.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/AbstractUtils.java
@@ -4,7 +4,7 @@ package de.wuespace.telestion.api.utils;
  * When class extends AbstractUtils it indicates that the extending class is a utility class which can not be
  * instantiated. There should be no callable constructors which is why the default constructor is also blocked.
  *
- * @author Cedric Boes, Ludwig Richter
+ * @author Cedric Boes (@cb0s), Ludwig Richter (@fussel178)
  */
 public abstract class AbstractUtils {
 	/**

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/AbstractUtils.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/AbstractUtils.java
@@ -1,0 +1,25 @@
+package de.wuespace.telestion.api.utils;
+
+/**
+ * When class extends AbstractUtils it indicates that the extending class is a utility class which can not be
+ * instantiated. There should be no callable constructors which is why the default constructor is also blocked.
+ *
+ * @author Cedric Boes, Ludwig Richter
+ */
+public abstract class AbstractUtils {
+	/**
+	 * There shall be no objects of a Utility class. This is why this constructor throws an
+	 * {@link UnsupportedOperationException}.
+	 *
+	 * @throws UnsupportedOperationException Will always be thrown because there shall be no objects of a utility class
+	 */
+	// Utility classes do not have objects
+	protected AbstractUtils() throws UnsupportedOperationException {
+		var className = this.getClass().getName();
+		var errorMsg = String.format("""
+				There shall be no objects of a utility class!
+				%s extending AbstractUtils is automatically a utility class. It must not be instantiated.""",
+				className);
+		throw new UnsupportedOperationException(errorMsg);
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/NoSuchPrimitiveTypeException.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/NoSuchPrimitiveTypeException.java
@@ -1,32 +1,37 @@
 package de.wuespace.telestion.api.utils;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 /**
  * Thrown to indicate that the primitive type parser has attempted to parse the raw value to its primitive type,
  * but that the given primitive class type is not known.
- *
+ * <p>
  * If that exception occurs, please check if the primitive type parser knows
  * from the given primitive class type before continuing.
  *
- * @see PrimitiveTypeParser
  * @author Ludwig Richter
+ * @see PrimitiveTypeParser
  */
-public class NoSuchPrimitiveTypeException extends Exception {
+public class NoSuchPrimitiveTypeException extends RuntimeException {
 	private final Class<?> clazz;
 
 	/**
 	 * Constructs a {@code NoSuchPrimitiveTypeException} with the unknown primitive class type
 	 * and an additional cause.
+	 *
 	 * @param clazz the unknown primitive class type
 	 * @param cause an additional cause
 	 */
 	public NoSuchPrimitiveTypeException(Class<?> clazz, Throwable cause) {
-		super("Given primitive " + clazz.getName() +
-				" cannot be used to parse a primitive value. Maybe it is not a primitive type at all?", cause);
+		super("Given primitive %s cannot be used to parse a primitive value. Expected: %s, Got: %s"
+				.formatted(clazz.getName(), formattedSupportedPrimitiveTypes(), clazz.getName()), cause);
 		this.clazz = clazz;
 	}
 
 	/**
 	 * Constructs a {@code NoSuchPrimitiveTypeException} with the unknown primitive class type.
+	 *
 	 * @param clazz the unknown primitive class type
 	 */
 	public NoSuchPrimitiveTypeException(Class<?> clazz) {
@@ -36,9 +41,19 @@ public class NoSuchPrimitiveTypeException extends Exception {
 	/**
 	 * Returns the unknown primitive class type which causes this exception to be thrown
 	 * in the {@link PrimitiveTypeParser}.
+	 *
 	 * @return the unknown primitive class type
 	 */
 	public Class<?> getClazz() {
 		return this.clazz;
+	}
+
+	// [Integer, Long, ...]
+	private static String formattedSupportedPrimitiveTypes() {
+		return "[%s]".formatted(
+				Arrays.stream(PrimitiveTypeParser.getSupportedPrimitiveTypes())
+						.map(Class::getName)
+						.collect(Collectors.joining(", "))
+		);
 	}
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/NoSuchPrimitiveTypeException.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/NoSuchPrimitiveTypeException.java
@@ -1,0 +1,44 @@
+package de.wuespace.telestion.api.utils;
+
+/**
+ * Thrown to indicate that the primitive type parser has attempted to parse the raw value to its primitive type,
+ * but that the given primitive class type is not known.
+ *
+ * If that exception occurs, please check if the primitive type parser knows
+ * from the given primitive class type before continuing.
+ *
+ * @see PrimitiveTypeParser
+ * @author Ludwig Richter
+ */
+public class NoSuchPrimitiveTypeException extends Exception {
+	private final Class<?> clazz;
+
+	/**
+	 * Constructs a {@code NoSuchPrimitiveTypeException} with the unknown primitive class type
+	 * and an additional cause.
+	 * @param clazz the unknown primitive class type
+	 * @param cause an additional cause
+	 */
+	public NoSuchPrimitiveTypeException(Class<?> clazz, Throwable cause) {
+		super("Given primitive " + clazz.getName() +
+				" cannot be used to parse a primitive value. Maybe it is not a primitive type at all?", cause);
+		this.clazz = clazz;
+	}
+
+	/**
+	 * Constructs a {@code NoSuchPrimitiveTypeException} with the unknown primitive class type.
+	 * @param clazz the unknown primitive class type
+	 */
+	public NoSuchPrimitiveTypeException(Class<?> clazz) {
+		this(clazz, null);
+	}
+
+	/**
+	 * Returns the unknown primitive class type which causes this exception to be thrown
+	 * in the {@link PrimitiveTypeParser}.
+	 * @return the unknown primitive class type
+	 */
+	public Class<?> getClazz() {
+		return this.clazz;
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/NoSuchPrimitiveTypeException.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/NoSuchPrimitiveTypeException.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
  * If that exception occurs, please check if the primitive type parser knows
  * from the given primitive class type before continuing.
  *
- * @author Ludwig Richter
+ * @author Ludwig Richter (@fussel178)
  * @see PrimitiveTypeParser
  */
 public class NoSuchPrimitiveTypeException extends RuntimeException {

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
@@ -1,0 +1,64 @@
+package de.wuespace.telestion.api.utils;
+
+import java.util.HashMap;
+import java.util.function.Function;
+
+/**
+ * <p><strong>A utility class to parse values from strings for primitive types</strong></p>
+ *
+ * <p>
+ *     This utility class offers methods to parse values from a string input to primitive types via their class type.
+ * </p>
+ *
+ * @see #parse(String, Class)
+ * @see #parseUnsigned(String, Class)
+ * @author Cedric Boes, Ludwig Richter
+ */
+public class PrimitiveTypeParser {
+	/**
+	 * Tries to parse a value from the given string to the primitive type and throws
+	 * if the primitive class type is not known.
+	 * @param raw the encoded/raw value as string
+	 * @param primitiveClass the class of the primitive type to try to parse to
+	 * @return the parsed value in the primitive type
+	 * @throws NoSuchPrimitiveTypeException when the given primitive type is not known
+	 */
+	public static Object parse(String raw, Class<?> primitiveClass) throws NoSuchPrimitiveTypeException {
+		if (!mappings.containsKey(primitiveClass)) throw new NoSuchPrimitiveTypeException(primitiveClass);
+		return mappings.get(primitiveClass).apply(raw);
+	}
+
+	/**
+	 * Like {@link #parse(String, Class)} but parse integers as unsigned.
+	 * @param raw the encoded/raw value as string
+	 * @param primitiveClass the class of the primitive type to try to parse to
+	 * @return the parsed value in the primitive type
+	 * @throws NoSuchPrimitiveTypeException when the given primitive type is not known
+	 */
+	public static Object parseUnsigned(String raw, Class<?> primitiveClass) throws NoSuchPrimitiveTypeException {
+		if (!unsignedMappings.containsKey(primitiveClass)) throw new NoSuchPrimitiveTypeException(primitiveClass);
+		return unsignedMappings.get(primitiveClass).apply(raw);
+	}
+
+	// utils classes cannot be instantiated
+	private PrimitiveTypeParser() {}
+
+	private static final HashMap<Class<?>, Function<String, Object>> mappings = new HashMap<>();
+	private static final HashMap<Class<?>, Function<String, Object>> unsignedMappings = new HashMap<>();
+
+	static {
+		mappings.put(Byte.class, Byte::parseByte);
+		mappings.put(Character.class, s -> s.length() == 1 ? s.charAt(0) : null);
+		mappings.put(Short.class, Short::parseShort);
+		mappings.put(Integer.class, Integer::parseInt);
+		mappings.put(Long.class, Long::parseLong);
+		mappings.put(Float.class, Float::parseFloat);
+		mappings.put(Double.class, Double::parseDouble);
+		mappings.put(String.class, s -> s);
+
+		// fill unsigned with same content and overwrite primitive types that can be unsigned
+		unsignedMappings.putAll(mappings);
+		unsignedMappings.put(Integer.class, Integer::parseUnsignedInt);
+		unsignedMappings.put(Long.class, Long::parseUnsignedLong);
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
@@ -93,6 +93,8 @@ public class PrimitiveTypeParser extends AbstractUtils {
 	private static final HashMap<Class<?>, Object> defaults = new HashMap<>();
 
 	static {
+		mappings.put(boolean.class, Boolean::parseBoolean);
+		mappings.put(Boolean.class, Boolean::parseBoolean);
 		mappings.put(byte.class, Byte::parseByte);
 		mappings.put(Byte.class, Byte::parseByte);
 		mappings.put(char.class, s -> s.length() == 1 ? s.charAt(0) : '\0');
@@ -133,6 +135,8 @@ public class PrimitiveTypeParser extends AbstractUtils {
 		unsignedMappings.put(double.class, x -> unsignedFloatingCheck.apply(Double.parseDouble(x)));
 		unsignedMappings.put(Double.class, x -> unsignedFloatingCheck.apply(Double.parseDouble(x)));
 
+		defaults.put(boolean.class, false);
+		defaults.put(Boolean.class, false);
 		defaults.put(byte.class, (byte) 0);
 		defaults.put(Byte.class, (byte) 0);
 		defaults.put(char.class, '\0');

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
@@ -7,48 +7,76 @@ import java.util.function.Function;
  * <p><strong>A utility class to parse values from strings for primitive types</strong></p>
  *
  * <p>
- *     This utility class offers methods to parse values from a string input to primitive types via their class type.
+ * This utility class offers methods to parse values from a string input to primitive types via their class type.
  * </p>
  *
+ * @author Cedric Boes, Ludwig Richter
  * @see #parse(String, Class)
  * @see #parseUnsigned(String, Class)
- * @author Cedric Boes, Ludwig Richter
  */
-public class PrimitiveTypeParser {
+public class PrimitiveTypeParser extends AbstractUtils {
 	/**
 	 * Tries to parse a value from the given string to the primitive type and throws
 	 * if the primitive class type is not known.
-	 * @param raw the encoded/raw value as string
+	 *
+	 * @param raw            the encoded/raw value as string
 	 * @param primitiveClass the class of the primitive type to try to parse to
+	 * @param <T>            class representation of the primitive type
 	 * @return the parsed value in the primitive type
 	 * @throws NoSuchPrimitiveTypeException when the given primitive type is not known
 	 */
-	public static Object parse(String raw, Class<?> primitiveClass) throws NoSuchPrimitiveTypeException {
+	@SuppressWarnings("unchecked")
+	public static <T> T parse(String raw, Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
 		if (!mappings.containsKey(primitiveClass)) throw new NoSuchPrimitiveTypeException(primitiveClass);
-		return mappings.get(primitiveClass).apply(raw);
+		return (T) mappings.get(primitiveClass).apply(raw);
 	}
 
 	/**
 	 * Like {@link #parse(String, Class)} but parse integers as unsigned.
-	 * @param raw the encoded/raw value as string
+	 *
+	 * @param raw            the encoded/raw value as string
 	 * @param primitiveClass the class of the primitive type to try to parse to
+	 * @param <T>            class representation of the primitive type
 	 * @return the parsed value in the primitive type
 	 * @throws NoSuchPrimitiveTypeException when the given primitive type is not known
 	 */
-	public static Object parseUnsigned(String raw, Class<?> primitiveClass) throws NoSuchPrimitiveTypeException {
+	@SuppressWarnings("unchecked")
+	public static <T> T parseUnsigned(String raw, Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
 		if (!unsignedMappings.containsKey(primitiveClass)) throw new NoSuchPrimitiveTypeException(primitiveClass);
-		return unsignedMappings.get(primitiveClass).apply(raw);
+		return (T) unsignedMappings.get(primitiveClass).apply(raw);
 	}
 
-	// utils classes cannot be instantiated
-	private PrimitiveTypeParser() {}
+	/**
+	 * Returns the default value for this primitive type and throws
+	 * if the primitive class type is not known.
+	 *
+	 * @param primitiveClass the class of the primitive type
+	 * @param <T>            class representation of the primitive type
+	 * @return the default value for this primitive type
+	 * @throws NoSuchPrimitiveTypeException when the given primitive type is not known
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T getDefault(Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
+		if (!defaults.containsKey(primitiveClass)) throw new NoSuchPrimitiveTypeException(primitiveClass);
+		return (T) defaults.get(primitiveClass);
+	}
+
+	/**
+	 * Returns all supported primitive types.
+	 *
+	 * @return all supported primitive types as class type list
+	 */
+	public static Class<?>[] getSupportedPrimitiveTypes() {
+		return mappings.keySet().toArray(Class<?>[]::new);
+	}
 
 	private static final HashMap<Class<?>, Function<String, Object>> mappings = new HashMap<>();
 	private static final HashMap<Class<?>, Function<String, Object>> unsignedMappings = new HashMap<>();
+	private static final HashMap<Class<?>, Object> defaults = new HashMap<>();
 
 	static {
 		mappings.put(Byte.class, Byte::parseByte);
-		mappings.put(Character.class, s -> s.length() == 1 ? s.charAt(0) : null);
+		mappings.put(Character.class, s -> s.length() == 1 ? s.charAt(0) : '\0');
 		mappings.put(Short.class, Short::parseShort);
 		mappings.put(Integer.class, Integer::parseInt);
 		mappings.put(Long.class, Long::parseLong);
@@ -60,5 +88,14 @@ public class PrimitiveTypeParser {
 		unsignedMappings.putAll(mappings);
 		unsignedMappings.put(Integer.class, Integer::parseUnsignedInt);
 		unsignedMappings.put(Long.class, Long::parseUnsignedLong);
+
+		defaults.put(Byte.class, (byte) 0);
+		defaults.put(Character.class, '\0');
+		defaults.put(Short.class, (short) 0);
+		defaults.put(Integer.class, 0);
+		defaults.put(Long.class, 0L);
+		defaults.put(Float.class, 0.0f);
+		defaults.put(Double.class, 0.0);
+		defaults.put(String.class, null);
 	}
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
@@ -75,26 +75,42 @@ public class PrimitiveTypeParser extends AbstractUtils {
 	private static final HashMap<Class<?>, Object> defaults = new HashMap<>();
 
 	static {
+		mappings.put(byte.class, Byte::parseByte);
 		mappings.put(Byte.class, Byte::parseByte);
+		mappings.put(char.class, s -> s.length() == 1 ? s.charAt(0) : '\0');
 		mappings.put(Character.class, s -> s.length() == 1 ? s.charAt(0) : '\0');
+		mappings.put(short.class, Short::parseShort);
 		mappings.put(Short.class, Short::parseShort);
+		mappings.put(int.class, Integer::parseInt);
 		mappings.put(Integer.class, Integer::parseInt);
+		mappings.put(long.class, Long::parseLong);
 		mappings.put(Long.class, Long::parseLong);
+		mappings.put(float.class, Float::parseFloat);
 		mappings.put(Float.class, Float::parseFloat);
+		mappings.put(double.class, Double::parseDouble);
 		mappings.put(Double.class, Double::parseDouble);
 		mappings.put(String.class, s -> s);
 
 		// fill unsigned with same content and overwrite primitive types that can be unsigned
 		unsignedMappings.putAll(mappings);
+		unsignedMappings.put(int.class, Integer::parseUnsignedInt);
 		unsignedMappings.put(Integer.class, Integer::parseUnsignedInt);
+		unsignedMappings.put(long.class, Long::parseUnsignedLong);
 		unsignedMappings.put(Long.class, Long::parseUnsignedLong);
 
+		defaults.put(byte.class, (byte) 0);
 		defaults.put(Byte.class, (byte) 0);
+		defaults.put(char.class, '\0');
 		defaults.put(Character.class, '\0');
+		defaults.put(short.class, (short) 0);
 		defaults.put(Short.class, (short) 0);
+		defaults.put(int.class, 0);
 		defaults.put(Integer.class, 0);
+		defaults.put(long.class, 0L);
 		defaults.put(Long.class, 0L);
+		defaults.put(float.class, 0.0f);
 		defaults.put(Float.class, 0.0f);
+		defaults.put(double.class, 0.0);
 		defaults.put(Double.class, 0.0);
 		defaults.put(String.class, null);
 	}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
@@ -25,11 +25,12 @@ public class PrimitiveTypeParser extends AbstractUtils {
 	 * @return the parsed value in the primitive type
 	 * @throws NoSuchPrimitiveTypeException when the given primitive type is not known or casting goes wrong
 	 */
+	@SuppressWarnings("unchecked")
 	public static <T> T parse(String raw, Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
 		if (!mappings.containsKey(primitiveClass)) throw new NoSuchPrimitiveTypeException(primitiveClass);
 		try {
-			return primitiveClass.cast(mappings.get(primitiveClass).apply(raw));
-		} catch (ClassCastException e) {
+			return (T) mappings.get(primitiveClass).apply(raw);
+		} catch (NullPointerException | ClassCastException e) {
 			throw new NoSuchPrimitiveTypeException(primitiveClass, e);
 		}
 	}
@@ -49,12 +50,13 @@ public class PrimitiveTypeParser extends AbstractUtils {
 	 * @return the parsed value in the primitive type
 	 * @throws NoSuchPrimitiveTypeException when the given primitive type is not known or casting goes wrong
 	 */
+	@SuppressWarnings("unchecked")
 	public static <T> T parseUnsigned(String raw, Class<T> primitiveClass) throws NoSuchPrimitiveTypeException {
 		// TODO: We might need to improve support for unsigned values in the future at some point...
 		if (!unsignedMappings.containsKey(primitiveClass)) throw new NoSuchPrimitiveTypeException(primitiveClass);
 		try {
-			return primitiveClass.cast(unsignedMappings.get(primitiveClass).apply(raw));
-		} catch (ClassCastException e) {
+			return (T) unsignedMappings.get(primitiveClass).apply(raw);
+		} catch (NullPointerException | ClassCastException e) {
 			throw new NoSuchPrimitiveTypeException(primitiveClass, e);
 		}
 	}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/PrimitiveTypeParser.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
  * This utility class offers methods to parse values from a string input to primitive types via their class type.
  * </p>
  *
- * @author Cedric Boes, Ludwig Richter
+ * @author Cedric Boes (@cb0s), Ludwig Richter (@fussel178)
  * @see #parse(String, Class)
  * @see #parseUnsigned(String, Class)
  */

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/package-info.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/utils/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * <h2>Telestion API utilities</h2>
+ *
+ * Contains general utility classes for the Telestion ecosystem.
+ * <p>
+ * To indicate a class is a Telestion-utility class,
+ * it extends {@link de.wuespace.telestion.api.utils.AbstractUtils AbstractUtils}.
+ * When trying to instantiate them, an {@link java.lang.UnsupportedOperationException} is thrown to inform the user of
+ * the api of the incorrect usage.
+ * <p>
+ * (c) WueSpace e.V.
+ */
+package de.wuespace.telestion.api.utils;

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/GenericConfiguration.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/GenericConfiguration.java
@@ -1,4 +1,10 @@
 package de.wuespace.telestion.api.verticle;
 
+/**
+ * The Configuration class which should be used if no config is needed to infer the generics of a
+ * {@link TelestionVerticle}.
+ *
+ * @author Cedric Boes (cb0s), Ludwig Richter (@fussel178)
+ */
 public record GenericConfiguration() implements TelestionConfiguration {
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionConfiguration.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionConfiguration.java
@@ -6,7 +6,8 @@ import de.wuespace.telestion.api.message.JsonMessage;
  * The base class for all Telestion Verticle configurations.
  * It extends {@link JsonMessage} so all configurations are also valid json classes.
  *
- * @author Cedric Bös, Pablo Klaschka, Jan von Pichowski, Ludwig Richter
+ * @author Cedric Boes (cb0s), Pablo Klaschka (@pklaschka), Jan von Pichowski (@jvpichowski),
+ * 			Ludwig Richter (@fussel178)
  */
 public interface TelestionConfiguration extends JsonMessage {
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionVerticle.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionVerticle.java
@@ -15,7 +15,8 @@ import java.lang.reflect.ParameterizedType;
  * and type-safe usage of the configuration JSON object provided by Vert.x.
  *
  * @param <T> the type of your Configuration class
- * @author Cedric Bös, Pablo Klaschka, Jan von Pichowski, Ludwig Richter
+ * @author Cedric Boes (@cb0s), Pablo Klaschka (@pklaschka), Jan von Pichowski (@jvpichowski),
+ * 			Ludwig Richter (@fussel178)
  */
 public abstract class TelestionVerticle<T extends TelestionConfiguration> extends AbstractVerticle {
 	/**

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/package-info.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/package-info.java
@@ -1,5 +1,5 @@
 /**
- * <h2>Telestion API - Telestion Verticle<h2>
+ * <h2>Telestion API - Telestion Verticle</h2>
  *
  * This package contains different classes helping with Vert.X verticles by providing often used methods which help
  * to improve the developer experience by massively reducing boiler-plate code.
@@ -17,7 +17,7 @@
  * By implementing {@link de.wuespace.telestion.api.verticle.trait traits} the functionality of the
  * {@link de.wuespace.telestion.api.verticle.TelestionVerticle} can be increased even more.
  * <h3>Examples</h3>
- * For examples refer to the {@link de.wuespace.telestion.example de.wuespace.telestion.example-package}.
+ * For examples refer to the {@code de.wuespace.telestion.example-package}.
  * <p>
  * (c) WueSpace e.V.
  *

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
@@ -4,6 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import de.wuespace.telestion.api.message.JsonMessage;
 import io.vertx.core.eventbus.Message;
 
+/**
+ * A Record extending {@link JsonMessage} containing, both, the parsed JsonMessage and the raw message.
+ *
+ * @param body parsed message which is easier to use than the raw JSON
+ * @param message raw, unparsed message
+ * @param <T>	type of parsed {@link JsonMessage}
+ * @author Cedric Boes (cb0s), Ludwig Richter (@fussel178), Pablo Klaschka (@pklaschka)
+ */
 public record DecodedMessage<T extends JsonMessage>(
 		@JsonProperty T body,
 		@JsonProperty Message<Object> message

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/ExtendedMessageHandler.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/ExtendedMessageHandler.java
@@ -3,7 +3,24 @@ package de.wuespace.telestion.api.verticle.trait;
 import de.wuespace.telestion.api.message.JsonMessage;
 import io.vertx.core.eventbus.Message;
 
+/**
+ * {@link FunctionalInterface} which is used to handle Vert.X messages from the event bus. By inferring the generics of
+ * this class with a {@link JsonMessage}, an implementation can link a raw message to a {@link JsonMessage} again,
+ * before calling the handler itself - {@link #handle(JsonMessage, Message)}.
+ * <p>
+ * The difference to {@link MessageHandler} is, that this handler still has access to the raw message, which allows it,
+ * to e.g. access the message header and other delivery options.
+ *
+ * @param <T>	{@link JsonMessage} to handle
+ * @author Cedric Boes (cb0s), Ludwig Richter (@fussel178), Pablo Klaschka (@pklaschka)
+ */
 @FunctionalInterface
 public interface ExtendedMessageHandler<T extends JsonMessage> {
+	/**
+	 * The function handling the message.
+	 *
+	 * @param body parsed {@link JsonMessage} to handle
+	 * @param message raw message before parsing
+	 */
 	void handle(T body, Message<Object> message);
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/MessageHandler.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/MessageHandler.java
@@ -2,7 +2,20 @@ package de.wuespace.telestion.api.verticle.trait;
 
 import de.wuespace.telestion.api.message.JsonMessage;
 
+/**
+ * {@link FunctionalInterface} which is used to handle Vert.X messages from the event bus. By inferring the generics of
+ * this class with a {@link JsonMessage}, an implementation can link a raw message to a {@link JsonMessage} again,
+ * before calling the handler itself - {@link #handle(JsonMessage)}.
+ *
+ * @param <T>	{@link JsonMessage} to handle
+ * @author Cedric Boes (cb0s), Ludwig Richter (@fussel178), Pablo Klaschka (@pklaschka)
+ */
 @FunctionalInterface
 public interface MessageHandler<T extends JsonMessage> {
+	/**
+	 * The function handling the parsed message object.
+	 *
+	 * @param body parsed {@link JsonMessage} to handle
+	 */
 	void handle(T body);
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/WithSharedData.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/WithSharedData.java
@@ -20,7 +20,7 @@ import io.vertx.core.shareddata.LocalMap;
  * }
  * </pre>
  *
- * @author Pablo Klaschka, Ludwig Richter
+ * @author Pablo Klaschka (@pklaschka), Ludwig Richter (@fussel178)
  */
 public interface WithSharedData extends Verticle {
 	/**

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/package-info.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/package-info.java
@@ -8,7 +8,7 @@
  * <p>
  * To use them, a {@link de.wuespace.telestion.api.verticle.TelestionVerticle} must simply implement one of the traits.
  * <p>
- * Refer to the examples in {@link de.wuespace.telestion.example}.
+ * Refer to the examples in {@code de.wuespace.telestion.example}.
  * <p>
  * (c) WueSpace e.V.
  *

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationReceiver.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationReceiver.java
@@ -1,0 +1,28 @@
+package de.wuespace.telestion.example;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.verticle.TelestionConfiguration;
+import de.wuespace.telestion.api.verticle.TelestionVerticle;
+import de.wuespace.telestion.api.verticle.trait.WithEventBus;
+import de.wuespace.telestion.example.information.SimpleInformation;
+import de.wuespace.telestion.example.messages.SimpleMessage;
+
+import java.util.Objects;
+
+public class InformationReceiver extends TelestionVerticle<InformationReceiver.Configuration> implements WithEventBus {
+	public record Configuration(@JsonProperty String inAddress) implements TelestionConfiguration {
+	}
+
+	@Override
+	public void onStart() {
+		register(getConfig().inAddress(), (body, message) -> {
+			var info = SimpleInformation.fromHeaders(message.headers());
+			if (Objects.isNull(info)) {
+				logger.warn("Cannot extract simple information from header!");
+			} else {
+				logger.info("Received from Information sender: {}", info);
+			}
+		}, SimpleMessage.class);
+		logger.info("InformationReceiver started");
+	}
+}

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationSender.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationSender.java
@@ -44,7 +44,7 @@ public class InformationSender extends TelestionVerticle<InformationSender.Confi
 		map.put("value2", value2);
 		logger.info("New values for InformationReceiver: {}:{}", value1, value2);
 
-		var info = new SimpleInformation(value1, value2, 'a', null, "Hello World");
+		var info = new SimpleInformation(value1, value2, 'a', null, "Hello World", 4);
 		publish(getConfig().outAddress(), new SimpleMessage("Hello World", "This is a test message"), info);
 		logger.debug("Sent message");
 	}

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationSender.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationSender.java
@@ -44,7 +44,7 @@ public class InformationSender extends TelestionVerticle<InformationSender.Confi
 		map.put("value2", value2);
 		logger.info("New values for InformationReceiver: {}:{}", value1, value2);
 
-		var info = new SimpleInformation(value1, value2, 'a', null, "Hello World", 4);
+		var info = new SimpleInformation(value1, value2, 'a', null, "Hello World", 4, true);
 		publish(getConfig().outAddress(), new SimpleMessage("Hello World", "This is a test message"), info);
 		logger.debug("Sent message");
 	}

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationSender.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationSender.java
@@ -1,0 +1,54 @@
+package de.wuespace.telestion.example;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.header.Information;
+import de.wuespace.telestion.api.verticle.TelestionConfiguration;
+import de.wuespace.telestion.api.verticle.TelestionVerticle;
+import de.wuespace.telestion.api.verticle.trait.WithEventBus;
+import de.wuespace.telestion.api.verticle.trait.WithSharedData;
+import de.wuespace.telestion.example.information.SimpleInformation;
+import de.wuespace.telestion.example.messages.SimpleMessage;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.LocalMap;
+
+import java.time.Duration;
+
+public class InformationSender extends TelestionVerticle<InformationSender.Configuration>
+		implements WithEventBus, WithSharedData {
+	public static void main(String[] args) {
+		var vertx = Vertx.vertx();
+
+		var senderConfig = new InformationSender.Configuration("simple-information");
+		var receiverConfig = new InformationReceiver.Configuration("simple-information");
+
+		vertx.deployVerticle(InformationSender.class, new DeploymentOptions().setConfig(senderConfig.json()));
+		vertx.deployVerticle(InformationReceiver.class, new DeploymentOptions().setConfig(receiverConfig.json()));
+	}
+
+	public record Configuration(@JsonProperty String outAddress) implements TelestionConfiguration {
+	}
+
+	@Override
+	public void onStart() {
+		vertx.setPeriodic(Duration.ofSeconds(1).toMillis(), this::sendMessage);
+		logger.info("InformationSender started");
+	}
+
+	private void sendMessage(Long intervalId) {
+		logger.debug("Try to send new message with information");
+		LocalMap<String, Integer> map = localMap(MAP_KEY);
+		int value1 = map.getOrDefault("value1", 0) + 1;
+		int value2 = map.getOrDefault("value2", 0) + 1;
+
+		map.put("value1", value1);
+		map.put("value2", value2);
+		logger.info("New values for InformationReceiver: {}:{}", value1, value2);
+
+		var info = new SimpleInformation(value1, value2, 'a', null, "Hello World");
+		publish(getConfig().outAddress(), new SimpleMessage("Hello World", "This is a test message"), info);
+		logger.debug("Sent message");
+	}
+
+	private static final String MAP_KEY = InformationSender.class.getName();
+}

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationSender.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/InformationSender.java
@@ -1,7 +1,6 @@
 package de.wuespace.telestion.example;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import de.wuespace.telestion.api.header.Information;
 import de.wuespace.telestion.api.verticle.TelestionConfiguration;
 import de.wuespace.telestion.api.verticle.TelestionVerticle;
 import de.wuespace.telestion.api.verticle.trait.WithEventBus;

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/information/SimpleInformation.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/information/SimpleInformation.java
@@ -10,7 +10,8 @@ public record SimpleInformation(
 		@SerializationInfo(name = "char1") char char1,
 		@SerializationInfo(name = "char2") Character char2,
 		@SerializationInfo(name = "str") String str,
-		@SerializationInfo(name = "unsigned-int", defaultValue = "0", isUnsigned = true) int unsignedInt
+		@SerializationInfo(name = "unsigned-int", defaultValue = "0", isUnsigned = true) int unsignedInt,
+		@SerializationInfo(name = "boolean") boolean bool
 ) implements Information {
 	// fromHeaders(MultiMap) is optional but improves the developer experience in our opinion
 	public static SimpleInformation fromHeaders(MultiMap headers) {

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/information/SimpleInformation.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/information/SimpleInformation.java
@@ -9,7 +9,8 @@ public record SimpleInformation(
 		@SerializationInfo(name = "value2") Integer value2,
 		@SerializationInfo(name = "char1") char char1,
 		@SerializationInfo(name = "char2") Character char2,
-		@SerializationInfo(name = "str") String str
+		@SerializationInfo(name = "str") String str,
+		@SerializationInfo(name = "unsigned-int", defaultValue = "0", isUnsigned = true) int unsignedInt
 ) implements Information {
 	// fromHeaders(MultiMap) is optional but improves the developer experience in our opinion
 	public static SimpleInformation fromHeaders(MultiMap headers) {

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/information/SimpleInformation.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/information/SimpleInformation.java
@@ -1,7 +1,7 @@
 package de.wuespace.telestion.example.information;
 
-import de.wuespace.telestion.api.header.Information;
-import de.wuespace.telestion.api.header.serialization.SerializationInfo;
+import de.wuespace.telestion.api.message.header.Information;
+import de.wuespace.telestion.api.message.header.serialization.SerializationInfo;
 import io.vertx.core.MultiMap;
 
 public record SimpleInformation(

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/information/SimpleInformation.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/information/SimpleInformation.java
@@ -1,0 +1,18 @@
+package de.wuespace.telestion.example.information;
+
+import de.wuespace.telestion.api.header.Information;
+import de.wuespace.telestion.api.header.serialization.SerializationInfo;
+import io.vertx.core.MultiMap;
+
+public record SimpleInformation(
+		@SerializationInfo(name = "value1", defaultValue = "4") int value1,
+		@SerializationInfo(name = "value2") Integer value2,
+		@SerializationInfo(name = "char1") char char1,
+		@SerializationInfo(name = "char2") Character char2,
+		@SerializationInfo(name = "str") String str
+) implements Information {
+	// fromHeaders(MultiMap) is optional but improves the developer experience in our opinion
+	public static SimpleInformation fromHeaders(MultiMap headers) {
+		return Information.fromHeaders(headers, SimpleInformation.class);
+	}
+}

--- a/modules/telestion-example/src/main/java/de/wuespace/telestion/example/package-info.java
+++ b/modules/telestion-example/src/main/java/de/wuespace/telestion/example/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * <h2>Telestion Examples</h2>
+ *
+ * This module contains many different examples which can be referred to when exploring how to use the Telestion-Core.
+ * <p>
+ * (c) WueSpace e.V.
+ */
+package de.wuespace.telestion.example;


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

This PR improves the documentation of the API and adds Java support for Message Headers.

### Details <!-- Describe the content of the pull request -->

When using the Vert.X event bus, it is useful to, instead of adding more and more features to the JsonMessages (which are converted to JSON for the event bus), also use Message Headers. They are way more flexible which allows for a reuse of the already existing messages.
The features of the PR are shown in the examples module:
 - `InformationSender.java` sends messages also containing a header
 - `InformationReceiver.java` receives the messages with headers and logs them

Apart from that, the Telestion API is completely documented after accepting this PR. This includes the `package-info.java`-files which explain, what a package is about.
All authors now not only have their real names in the code (for copyright reasons) but also reference to their GitHub-Accounts which helps external developers to directly communicate the the respective developer.

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
