### PR TITLE
Automatic loading of default configuration in `TelestionVerticle`

### DIFF
--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionVerticle.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionVerticle.java
@@ -6,7 +6,9 @@ import io.vertx.core.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
+import java.util.Objects;
 
 /**
  * An abstract verticle class that you can extend to write your own verticle classes.
@@ -45,6 +47,7 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 
 	/**
 	 * Get the Configuration Class type from the inheriting class.
+	 *
 	 * @return the Configuration Class type
 	 */
 	@SuppressWarnings("unchecked")
@@ -58,6 +61,35 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 			logger.warn("Cannot get Class type from generic: {}", e.getMessage());
 			return null;
 		}
+	}
+
+	/**
+	 * Creates a new Telestion verticle and tries to load the default configuration
+	 * from the specified configuration class.
+	 *
+	 * @param skipDefaultConfigLoading when {@code true} the loading of the default configuration is skipped
+	 */
+	public TelestionVerticle(boolean skipDefaultConfigLoading) {
+		if (skipDefaultConfigLoading) return;
+		var configType = getConfigType();
+		if (Objects.isNull(configType)) return;
+
+		try {
+			var defaultConfig = configType.getConstructor().newInstance();
+			this.defaultConfig = defaultConfig;
+			this.defaultGenericConfig = defaultConfig.json();
+		} catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+			// no default configuration on configuration class found, ignoring
+			logger.debug("No default configuration found. Skip loading");
+		}
+	}
+
+	/**
+	 * Same as {@link TelestionVerticle#TelestionVerticle(boolean)}
+	 * but enables loading of default configuration if possible.
+	 */
+	public TelestionVerticle() {
+		this(false);
 	}
 
 	@Override
@@ -84,8 +116,8 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 	}
 
 	/**
-	 * @see AbstractVerticle#start(Promise)
 	 * @throws Exception
+	 * @see AbstractVerticle#start(Promise)
 	 */
 	public void onStart(Promise<Void> startPromise) throws Exception {
 		onStart();
@@ -93,15 +125,15 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 	}
 
 	/**
-	 * @see AbstractVerticle#start()
 	 * @throws Exception
+	 * @see AbstractVerticle#start()
 	 */
 	public void onStart() throws Exception {
 	}
 
 	/**
-	 * @see AbstractVerticle#stop(Promise)
 	 * @throws Exception
+	 * @see AbstractVerticle#stop(Promise)
 	 */
 	public void onStop(Promise<Void> stopPromise) throws Exception {
 		onStop();
@@ -109,14 +141,15 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 	}
 
 	/**
-	 * @see AbstractVerticle#stop()
 	 * @throws Exception
+	 * @see AbstractVerticle#stop()
 	 */
 	public void onStop() throws Exception {
 	}
 
 	/**
 	 * Set the default verticle configuration and update the verticle configuration.
+	 *
 	 * @param defaultConfig the new default verticle configuration
 	 */
 	public void setDefaultConfig(JsonObject defaultConfig) {
@@ -127,6 +160,7 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 
 	/**
 	 * Set the default verticle configuration and update the verticle configuration.
+	 *
 	 * @param defaultConfig the new default verticle configuration
 	 */
 	public void setDefaultConfig(T defaultConfig) {
@@ -138,6 +172,7 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 	/**
 	 * Get the default verticle configuration in the Configuration type format.<p>
 	 * Returns <code>null</code> when no type via {@link #getConfigType()} is given.
+	 *
 	 * @return the default verticle configuration
 	 */
 	public T getDefaultConfig() {
@@ -146,6 +181,7 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 
 	/**
 	 * Get the default verticle configuration in a generic format.
+	 *
 	 * @return the default verticle configuration
 	 */
 	public JsonObject getGenericDefaultConfig() {
@@ -155,6 +191,7 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 	/**
 	 * Get the verticle configuration in the Configuration type format.<p>
 	 * Returns <code>null</code> when no type via {@link #getConfigType()} is given.
+	 *
 	 * @return the verticle configuration
 	 */
 	public T getConfig() {
@@ -163,6 +200,7 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 
 	/**
 	 * Get the verticle configuration in a generic format.
+	 *
 	 * @return the verticle configuration
 	 */
 	public JsonObject getGenericConfig() {
@@ -171,6 +209,7 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 
 	/**
 	 * Block the usage of <code>config()</code> in inheriting classes.
+	 *
 	 * @return the verticle configuration from vertx merged with the default configuration
 	 */
 	@Override
@@ -189,6 +228,7 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 	/**
 	 * Map a generic JSON object to the Configuration type.<p>
 	 * Returns <code>null</code> when no type via {@link #getConfigType()} is given.
+	 *
 	 * @param object the generic JSON object to map
 	 * @return the JSON object in the Configuration type format
 	 */

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionVerticle.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionVerticle.java
@@ -70,9 +70,13 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 	 * @param skipDefaultConfigLoading when {@code true} the loading of the default configuration is skipped
 	 */
 	public TelestionVerticle(boolean skipDefaultConfigLoading) {
-		if (skipDefaultConfigLoading) return;
+		if (skipDefaultConfigLoading) {
+			return;
+		}
 		var configType = getConfigType();
-		if (Objects.isNull(configType)) return;
+		if (Objects.isNull(configType)) {
+			return;
+		}
 
 		try {
 			var defaultConfig = configType.getConstructor().newInstance();

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionVerticle.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/TelestionVerticle.java
@@ -80,7 +80,10 @@ public abstract class TelestionVerticle<T extends TelestionConfiguration> extend
 			this.defaultGenericConfig = defaultConfig.json();
 		} catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
 			// no default configuration on configuration class found, ignoring
-			logger.debug("No default configuration found. Skip loading");
+			logger.info("No default configuration found for {}. " +
+							"Expected constructor with no arguments to exist on {}. " +
+							"Continuing without default configuration.",
+					getClass().getSimpleName(), getConfigType().getSimpleName());
 		}
 	}
 

--- a/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/DefaultConfigVerticle.java
+++ b/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/DefaultConfigVerticle.java
@@ -1,0 +1,51 @@
+package de.wuespace.telestion.examples;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.verticle.TelestionConfiguration;
+import de.wuespace.telestion.api.verticle.TelestionVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+
+import java.time.Duration;
+
+/**
+ * A very simple verticle which should present the usage of automatic loading
+ * of the default configuration in a Telestion verticle.
+ *
+ * @author Ludwig Richter
+ */
+@SuppressWarnings("unused")
+public class DefaultConfigVerticle extends TelestionVerticle<DefaultConfigVerticle.Configuration> {
+
+	public record Configuration(
+			@JsonProperty String message
+	) implements TelestionConfiguration {
+		// this constructor gets called, when the default configuration is loaded from the base class
+		public Configuration() {
+			// set some nice defaults
+			this("I'm the default message. Feel free to change me! :D");
+		}
+	}
+
+	public static void main(String[] args) {
+		var vertx = Vertx.vertx();
+
+		var customConfiguration = new Configuration("I'm a custom message. Don't change me! XD");
+		// deploy with default configuration
+		// the base class loads the default configuration on instantiation
+		vertx.deployVerticle(DefaultConfigVerticle.class, new DeploymentOptions());
+		// deploy with custom configuration (overwrite default configuration)
+		vertx.deployVerticle(DefaultConfigVerticle.class, new DeploymentOptions().setConfig(customConfiguration.json()));
+	}
+
+	public DefaultConfigVerticle() {
+		// uncomment, if you don't want the automatic loading of the default configuration during instantiation
+//		super(true);
+	}
+
+	@Override
+	public void onStart() {
+		var delay = Duration.ofSeconds(1).toMillis();
+		vertx.setPeriodic(delay, id -> logger.info(getConfig().message()));
+	}
+}


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

Adds functionaltiy to `TelestionVerticle` that tries to load the default configuration from the configuration class.

### Details <!-- Describe the content of the pull request -->

- add two constructors to `TelestionVerticle` which try load the default configuration
- add an example which shows the usage of the "autoload" feature of the `TelestionVerticle`

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

During the migration in the https://github.com/wuespace/telestion-project-daedalus2, I always load the default configuration through the default constructor of the configuration class, like so:

```java
public class SomeVerticle extends TelestionVerticle<SomeVerticle.Configuration> {

	public record Configuration(
		@JsonProperty String someProperty
	) implements TelestionConfiguration {
		public Configuration() {
			this("Some default configuration. Feel free to overwrite me!");
		}
	}

	@Overwrite
	public void onStart() {
		setDefaultConfiguration(new Configuration());
		// use normal configuration, do something else, etc.
	}
}
```

Well,  that's repetitive. Let the base class do that, I think. :upside_down_face: 

And here is the new example:
https://github.com/wuespace/telestion-core/blob/1061e43228f2d857e1867c45e74cad119e3fa916/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/DefaultConfigVerticle.java

If you don't like this feature, you can turn it off in the constructor.

As always, I'm open for suggestions. :wink: 

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
