### PR TITLE
New and improved Verticle traits

### DIFF
--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
@@ -3,9 +3,10 @@ package de.wuespace.telestion.api.verticle.trait;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import de.wuespace.telestion.api.message.JsonMessage;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
 
-public record DecodedMessage<V extends JsonMessage, T>(
+public record DecodedMessage<V extends JsonMessage, T extends JsonObject>(
 		@JsonProperty V body,
 		@JsonProperty Message<T> message
-		) implements JsonMessage {
+) implements JsonMessage {
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import de.wuespace.telestion.api.message.JsonMessage;
 import io.vertx.core.eventbus.Message;
 
-public record DecodedMessage<T extends JsonMessage>(
-		@JsonProperty T body,
-		@JsonProperty Message<Object> message
+public record DecodedMessage<V extends JsonMessage, T>(
+		@JsonProperty V body,
+		@JsonProperty Message<T> message
 		) implements JsonMessage {
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/ExtendedMessageHandler.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/ExtendedMessageHandler.java
@@ -4,6 +4,6 @@ import de.wuespace.telestion.api.message.JsonMessage;
 import io.vertx.core.eventbus.Message;
 
 @FunctionalInterface
-public interface ExtendedMessageHandler<T extends JsonMessage> {
-	void handle(T body, Message<Object> message);
+public interface ExtendedMessageHandler<V extends JsonMessage, T> {
+	void handle(V body, Message<T> message);
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/Timing.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/Timing.java
@@ -1,0 +1,20 @@
+package de.wuespace.telestion.api.verticle.trait;
+
+import io.vertx.core.Vertx;
+
+/**
+ * Stores information to a specific timing from Vert.x like the timing id or associated Vert.x instance.
+ * @param vertx the associated Vert.x instance
+ * @param id the id of the timing
+ *
+ * @author Ludwig Richter
+ */
+public record Timing(Vertx vertx, long id) {
+	/**
+	 * Cancels the timing on the associated Vert.x instance.
+	 * @return {@code true} if the timing was successfully cancelled
+	 */
+	public boolean cancel() {
+		return vertx.cancelTimer(id);
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/WithSharedData.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/WithSharedData.java
@@ -44,4 +44,33 @@ public interface WithSharedData extends Verticle {
 	default <K, V> Future<AsyncMap<K, V>> remoteMap(String storageSpace) {
 		return getVertx().sharedData().getAsyncMap(storageSpace);
 	}
+
+	/**
+	 * Return the default local map for this specific verticle.
+	 * @param <K> the type of the key
+	 * @param <V> the type of the value
+	 * @return the default local map for this specific verticle
+	 */
+	default <K, V> LocalMap<K, V> defaultLocalMap() {
+		return localMap(defaultStorageKey());
+	}
+
+	/**
+	 * Return the default remote map for this specific verticle.
+	 * @param <K> the type of the key
+	 * @param <V> the type of the value
+	 * @return the default remote map for this specific verticle
+	 */
+	default <K, V> Future<AsyncMap<K, V>> defaultRemoteMap() {
+		return remoteMap(defaultStorageKey());
+	}
+
+	/**
+	 * Return the default storage key for this specific verticle
+	 * used for the {@link #defaultLocalMap()} and {@link #defaultRemoteMap()} verticle storage spaces.
+	 * @return the default storage key for this specific verticle
+	 */
+	default String defaultStorageKey() {
+		return getClass().getName();
+	}
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/WithTiming.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/WithTiming.java
@@ -1,0 +1,92 @@
+package de.wuespace.telestion.api.verticle.trait;
+
+import io.vertx.core.Handler;
+import io.vertx.core.TimeoutStream;
+import io.vertx.core.Verticle;
+
+import java.time.Duration;
+
+/**
+ * Allows {@link Verticle} instances to get simplified access to the Vert.x timing functions
+ * like {@link io.vertx.core.Vertx#setPeriodic(long, Handler) setPeriodic}
+ * or {@link io.vertx.core.Vertx#setTimer(long, Handler) setTimer}.
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ * {@code
+ * public class MyVerticle extends TelestionVerticle<GenericConfiguration> implements WithTiming {
+ *     @Override
+ *     public void onStart() {
+ *         var delay = Duration.ofSeconds(1);
+ *         interval(delay, id -> logger.info("Ping!"));
+ *     }
+ * }
+ * }
+ * </pre>
+ *
+ * @author Ludwig Richter
+ */
+public interface WithTiming extends Verticle {
+
+	/**
+	 * Like {@link io.vertx.core.Vertx#setPeriodic(long, Handler) setPeriodic},
+	 * but returns a special handler which cancels the interval when called.
+	 * @return a handler which cancels the interval when called
+	 */
+	default Timing interval(long delay, Handler<Long> handler) {
+		var id = getVertx().setPeriodic(delay, handler);
+		return new Timing(getVertx(), id);
+	}
+
+	/**
+	 * Like {@link #interval(long, Handler)}, but accepts a {@link Duration}.
+	 */
+	default Timing interval(Duration delay, Handler<Long> handler) {
+		return interval(delay.toMillis(), handler);
+	}
+
+	/**
+	 * @see io.vertx.core.Vertx#periodicStream(long)
+	 */
+	default TimeoutStream intervalStream(long delay) {
+		return getVertx().periodicStream(delay);
+	}
+
+	/**
+	 * Like {@link #intervalStream(long)}, but accepts a {@link Duration}.
+	 */
+	default TimeoutStream intervalStream(Duration delay) {
+		return intervalStream(delay.toMillis());
+	}
+
+	/**
+	 * Like {@link io.vertx.core.Vertx#setTimer(long, Handler) setTimer},
+	 * but returns a special handler which cancels the timeout when called.
+	 * @return a handler which cancels the timeout when called
+	 */
+	default Timing timeout(long delay, Handler<Long> handler) {
+		var id = getVertx().setTimer(delay, handler);
+		return new Timing(getVertx(), id);
+	}
+
+	/**
+	 * Like {@link #timeout(long, Handler)}, but accepts a {@link Duration}.
+	 */
+	default Timing timeout(Duration delay, Handler<Long> handler) {
+		return timeout(delay.toMillis(), handler);
+	}
+
+	/**
+	 * @see io.vertx.core.Vertx#timerStream(long)
+	 */
+	default TimeoutStream timeoutStream(long delay) {
+		return getVertx().timerStream(delay);
+	}
+
+	/**
+	 * Like {@link #timeoutStream(long)}, but accepts a {@link Duration}.
+	 */
+	default TimeoutStream timeoutStream(Duration delay) {
+		return timeoutStream(delay.toMillis());
+	}
+}

--- a/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/TestVerticle.java
+++ b/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/TestVerticle.java
@@ -55,6 +55,8 @@ public class TestVerticle extends TelestionVerticle<TestVerticle.Configuration> 
 		remoteMap("blub").onComplete(res -> {
 			res.result().put("piep", "piep");
 		});
+
+		defaultLocalMap().put("my-property", "my-value");
 	}
 
 	private void handleStuff(SimpleMessage body, Message<Object> raw) {


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

This PR improves existing and adds new traits for Vert.x verticles.

### Details <!-- Describe the content of the pull request -->

- improves `request` and `register` methods in `WithEventBus` trait to handle generic types for the eventbus message
- add a default local and remote map in `WithSharedData` with a key based on the class name
- add `WithTiming` trait to simplify access to the timing methods `setInterval` and `setTimer` of Vert.x
- update examples to present the new traits' functionality

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
