### PR TITLE
Header Information revisited

### DIFF
--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
@@ -194,7 +194,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside an {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<String> get(String key) {
@@ -206,7 +206,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @param defaultValue the value which is returned if no value is assigned to the key
 	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
@@ -219,7 +219,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside an {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Byte> getByte(String key) {
@@ -231,7 +231,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @param defaultValue the value which is returned if no value is assigned to the key
 	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
@@ -244,7 +244,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside an {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Integer> getInt(String key) {
@@ -256,7 +256,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @param defaultValue the value which is returned if no value is assigned to the key
 	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
@@ -269,7 +269,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside an {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Long> getLong(String key) {
@@ -281,7 +281,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @param defaultValue the value which is returned if no value is assigned to the key
 	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
@@ -294,7 +294,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside an {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Float> getFloat(String key) {
@@ -306,7 +306,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @param defaultValue the value which is returned if no value is assigned to the key
 	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
@@ -319,7 +319,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside an {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Double> getDouble(String key) {
@@ -331,7 +331,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @param defaultValue the value which is returned if no value is assigned to the key
 	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
@@ -344,7 +344,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside an {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Character> getChar(String key) {
@@ -356,7 +356,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @param defaultValue the value which is returned if no value is assigned to the key
 	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
@@ -369,7 +369,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside an {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Boolean> getBoolean(String key) {
@@ -381,7 +381,7 @@ public class HeaderInformation {
 	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @param defaultValue the value which is returned if no value is assigned to the key
 	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
@@ -406,6 +406,7 @@ public class HeaderInformation {
 
 	/**
 	 * Appends multiple {@link String} values assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link String} values that you want to append to the key
@@ -418,6 +419,7 @@ public class HeaderInformation {
 
 	/**
 	 * Appends multiple {@link Character} values assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Character} values that you want to append to the key
@@ -430,6 +432,7 @@ public class HeaderInformation {
 
 	/**
 	 * Appends multiple {@link Integer} values assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Integer} values that you want to append to the key
@@ -442,6 +445,7 @@ public class HeaderInformation {
 
 	/**
 	 * Appends multiple {@link Long} values assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Long} values that you want to append to the key
@@ -454,6 +458,7 @@ public class HeaderInformation {
 
 	/**
 	 * Appends multiple {@link Short} values assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Short} values that you want to append to the key
@@ -466,6 +471,7 @@ public class HeaderInformation {
 
 	/**
 	 * Appends multiple {@link Byte} values assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Byte} values that you want to append to the key
@@ -478,6 +484,7 @@ public class HeaderInformation {
 
 	/**
 	 * Appends multiple {@link Double} values assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Double} values that you want to append to the key
@@ -490,6 +497,7 @@ public class HeaderInformation {
 
 	/**
 	 * Appends multiple {@link Boolean} values assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Boolean} values that you want to append to the key
@@ -502,6 +510,11 @@ public class HeaderInformation {
 
 	/**
 	 * Intermediate step to append a stream of strings to the wrapped {@link MultiMap Vert.x headers}.
+	 * Returns a reference to {@code this} for fluent design.
+	 *
+	 * @param key      the key to which the values should be assigned
+	 * @param stream   stream of values to assign to the given key
+	 * @return a reference to {@code this}, so the API can be used fluently
 	 */
 	private HeaderInformation add(String key, Stream<String> stream) {
 		var list = stream.toList();
@@ -518,8 +531,9 @@ public class HeaderInformation {
 
 	/**
 	 * Appends all values assigned to their keys from the {@link MultiMap} to already existing values.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
-	 * @param headers the {@link MultiMap} that contain the new values
+	 * @param headers the {@link MultiMap} that contains the new values
 	 *                which you want to append to the existing values
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#addAll(MultiMap)
@@ -531,8 +545,9 @@ public class HeaderInformation {
 
 	/**
 	 * Appends all values assigned to their keys from the {@link Map} to already existing values.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
-	 * @param headers the {@link Map} that contain the new values
+	 * @param headers the {@link Map} that contains the new values
 	 *                which you want to append to the existing values
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#addAll(Map)
@@ -544,8 +559,9 @@ public class HeaderInformation {
 
 	/**
 	 * Appends all values assigned to their keys from the {@link HeaderInformation} object to already existing values.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
-	 * @param information the {@link HeaderInformation} object that contain the new values
+	 * @param information the {@link HeaderInformation} object that contains the new values
 	 *                    which you want to append to the existing values
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#addAll(MultiMap)
@@ -559,7 +575,8 @@ public class HeaderInformation {
 	///
 
 	/**
-	 * Replaces multiple {@link String} values with the old allocation assigned to the key .
+	 * Replaces multiple {@link String} values with the old allocation assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link String} values that you want to replace with the old allocation
@@ -572,6 +589,7 @@ public class HeaderInformation {
 
 	/**
 	 * Replaces multiple {@link Character} values with the old allocation assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Character} values that you want to replace with the old allocation
@@ -584,6 +602,7 @@ public class HeaderInformation {
 
 	/**
 	 * Replaces multiple {@link Integer} values with the old allocation assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Integer} values that you want to replace with the old allocation
@@ -596,6 +615,7 @@ public class HeaderInformation {
 
 	/**
 	 * Replaces multiple {@link Long} values with the old allocation assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Long} values that you want to replace with the old allocation
@@ -608,6 +628,7 @@ public class HeaderInformation {
 
 	/**
 	 * Replaces multiple {@link Short} values with the old allocation assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Short} values that you want to replace with the old allocation
@@ -620,6 +641,7 @@ public class HeaderInformation {
 
 	/**
 	 * Replaces multiple {@link Byte} values with the old allocation assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Byte} values that you want to replace with the old allocation
@@ -632,6 +654,7 @@ public class HeaderInformation {
 
 	/**
 	 * Replaces multiple {@link Double} values with the old allocation assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Double} values that you want to replace with the old allocation
@@ -644,6 +667,7 @@ public class HeaderInformation {
 
 	/**
 	 * Replaces multiple {@link Float} values with the old allocation assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Float} values that you want to replace with the old allocation
@@ -656,6 +680,7 @@ public class HeaderInformation {
 
 	/**
 	 * Replaces multiple {@link Boolean} values with the old allocation assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key    the key to which the values are assigned
 	 * @param values the new {@link Boolean} values that you want to replace with the old allocation
@@ -669,6 +694,11 @@ public class HeaderInformation {
 	/**
 	 * Intermediate step to replace a stream of strings with the old allocation
 	 * in the wrapped {@link MultiMap Vert.x headers}.
+	 * Returns a reference to {@code this} for fluent design.
+	 *
+	 * @param key      the key to the values which should be replaced
+	 * @param stream   stream of values which replace the current values assigned to the given key
+	 * @return a reference to {@code this}, so the API can be used fluently
 	 */
 	private HeaderInformation set(String key, Stream<String> stream) {
 		var list = stream.toList();
@@ -686,7 +716,8 @@ public class HeaderInformation {
 	/**
 	 * Replaces all values assigned to their keys with the content of the {@link MultiMap}.
 	 * All remaining values are cleared.
-	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.<br>
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param headers the {@link MultiMap} that contains the new values assigned to their keys
 	 * @return a reference to {@code this}, so the API can be used fluently
@@ -700,7 +731,8 @@ public class HeaderInformation {
 	/**
 	 * Replaces all values assigned to their keys with the content of the {@link Map}.
 	 * All remaining values are cleared.
-	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.<br>
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param headers the {@link Map} that contains the new values assigned to their keys
 	 * @return a reference to {@code this}, so the API can be used fluently
@@ -714,7 +746,8 @@ public class HeaderInformation {
 	/**
 	 * Replaces all values assigned to their keys with the content of the {@link HeaderInformation} object.
 	 * All other existing key slots are cleared.
-	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.<br>
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param information the {@link HeaderInformation} object that contains the new values assigned to their keys
 	 * @return a reference to {@code this}, so the API can be used fluently
@@ -741,6 +774,7 @@ public class HeaderInformation {
 
 	/**
 	 * Removes all values assigned to the key.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @param key the key to which the values are assigned
 	 * @return a reference to {@code this}, so the API can be used fluently
@@ -753,6 +787,7 @@ public class HeaderInformation {
 
 	/**
 	 * Clears all values assigned to their keys.
+	 * Returns a reference to {@code this} for fluent design.
 	 *
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#clear()
@@ -785,7 +820,7 @@ public class HeaderInformation {
 	/**
 	 * Returns {@code true}, if the wrapped {@link MultiMap Vert.x headers} have no entries.
 	 *
-	 * @return returns {@code true} if the wrapped {@link MultiMap Vert.x headers} have no entries
+	 * @return {@code true} if the wrapped {@link MultiMap Vert.x headers} have no entries
 	 * @see MultiMap#isEmpty()
 	 */
 	public boolean isEmpty() {

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
@@ -512,8 +512,8 @@ public class HeaderInformation {
 	 * Intermediate step to append a stream of strings to the wrapped {@link MultiMap Vert.x headers}.
 	 * Returns a reference to {@code this} for fluent design.
 	 *
-	 * @param key      the key to which the values should be assigned
-	 * @param stream   stream of values to assign to the given key
+	 * @param key    the key to which the values should be assigned
+	 * @param stream stream of values to assign to the given key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 */
 	private HeaderInformation add(String key, Stream<String> stream) {
@@ -522,7 +522,8 @@ public class HeaderInformation {
 		if (contains(key)) {
 			var existing = getAll(key);
 			logger.warn("The header information object already contains values assigned to that key. " +
-					"Key: {}, Before: {}, Now: {}", key, existing, Stream.of(existing, list).toList());
+							"Appending new values to existing values. Key: {}, Before: {}, Now: {}",
+					key, existing, Stream.of(existing, list).toList());
 		}
 
 		headers.add(key, list);
@@ -696,8 +697,8 @@ public class HeaderInformation {
 	 * in the wrapped {@link MultiMap Vert.x headers}.
 	 * Returns a reference to {@code this} for fluent design.
 	 *
-	 * @param key      the key to the values which should be replaced
-	 * @param stream   stream of values which replace the current values assigned to the given key
+	 * @param key    the key to the values which should be replaced
+	 * @param stream stream of values which replace the current values assigned to the given key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 */
 	private HeaderInformation set(String key, Stream<String> stream) {
@@ -706,7 +707,7 @@ public class HeaderInformation {
 		if (contains(key)) {
 			var existing = getAll(key);
 			logger.warn("The header information object already contains values assigned to that key. " +
-					"Key: {}, Before: {}, Now: {}", key, existing, list);
+					"Overriding existing values with new values. Key: {}, Before: {}, Now: {}", key, existing, list);
 		}
 
 		headers.set(key, list);

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
@@ -504,7 +504,15 @@ public class HeaderInformation {
 	 * Intermediate step to append a stream of strings to the wrapped {@link MultiMap Vert.x headers}.
 	 */
 	private HeaderInformation add(String key, Stream<String> stream) {
-		headers.add(key, stream.toList());
+		var list = stream.toList();
+
+		if (contains(key)) {
+			var existing = getAll(key);
+			logger.warn("The header information object already contains values assigned to that key. " +
+					"Key: {}, Before: {}, Now: {}", key, existing, Stream.of(existing, list).toList());
+		}
+
+		headers.add(key, list);
 		return this;
 	}
 
@@ -663,7 +671,15 @@ public class HeaderInformation {
 	 * in the wrapped {@link MultiMap Vert.x headers}.
 	 */
 	private HeaderInformation set(String key, Stream<String> stream) {
-		headers.set(key, stream.toList());
+		var list = stream.toList();
+
+		if (contains(key)) {
+			var existing = getAll(key);
+			logger.warn("The header information object already contains values assigned to that key. " +
+					"Key: {}, Before: {}, Now: {}", key, existing, list);
+		}
+
+		headers.set(key, list);
 		return this;
 	}
 

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
@@ -3,6 +3,8 @@ package de.wuespace.telestion.api.message;
 import io.vertx.core.MultiMap;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.function.Function;
@@ -12,17 +14,11 @@ import java.util.stream.Stream;
  * <h2>Description</h2>
  *
  * <p>
- * Header information are useful to attach simple information to messages
- * that should be transferred over the Vert.x event bus.
+ * The {@link HeaderInformation} class wraps APIs to attach information to messages
+ * to transfer them over the {@link io.vertx.core.eventbus.EventBus Vert.x event bus}.
  * <p>
- * This implementation extends the already existing functionality
- * of the {@link Message Vert.x message} {@link MultiMap headers}
+ * This implementation extends the already existing functionality of the {@link MultiMap Vert.x message headers}
  * to allow storing and retrieving of other basic data types than {@link String}.
- * <p>
- * There are numerous interfaces that simplifies the usage with the existing features of Vert.x
- * and better support through the {@link de.wuespace.telestion.api.verticle.trait.WithEventBus WithEventBus trait}
- * for {@link io.vertx.core.Verticle Vert.x verticles}
- * and especially the {@link de.wuespace.telestion.api.verticle.TelestionVerticle TelestionVerticle}.
  *
  * <h2>Usage</h2>
  * <pre>
@@ -50,34 +46,35 @@ import java.util.stream.Stream;
  * </pre>
  *
  * @author Cedric Boes (@cb0s), Ludwig Richter (@fussel178)
+ * @see de.wuespace.telestion.api.verticle.trait.WithEventBus
  */
 public class HeaderInformation {
 
 	/**
-	 * Merges an array of header information into one header information object.
+	 * Merges an array of {@link HeaderInformation} objects into one {@link HeaderInformation} object.
 	 *
-	 * @param information multiple header information that should be merged into one
-	 * @return the merged header information
+	 * @param information multiple {@link HeaderInformation} objects you want to merge
+	 * @return the merged {@link HeaderInformation} object
 	 */
 	public static HeaderInformation merge(HeaderInformation... information) {
 		return merge(Arrays.stream(information));
 	}
 
 	/**
-	 * Merges a list of header information into one header information object.
+	 * Merges a list of {@link HeaderInformation} objects into one {@link HeaderInformation} object.
 	 *
-	 * @param list multiple header information that should be merged into one
-	 * @return the merged header information
+	 * @param list multiple {@link HeaderInformation} objects you want to merge
+	 * @return the merged {@link HeaderInformation} object
 	 */
 	public static HeaderInformation merge(List<HeaderInformation> list) {
 		return merge(list.stream());
 	}
 
 	/**
-	 * Merges a stream of header information into one header information object.
+	 * Merges a stream of {@link HeaderInformation} objects into one {@link HeaderInformation} object.
 	 *
-	 * @param stream a stream that contains multiple header information that should be merged into one
-	 * @return the merged header information
+	 * @param stream a stream that contains multiple {@link HeaderInformation} objects you want to merge
+	 * @return the merged {@link HeaderInformation} object
 	 */
 	public static HeaderInformation merge(Stream<HeaderInformation> stream) {
 		var headers = stream.map(HeaderInformation::getHeaders);
@@ -85,37 +82,41 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Creates new header information from existing {@link MultiMap Vert.x headers}.
+	 * Creates a new {@link HeaderInformation} object from existing {@link MultiMap Vert.x headers}.
 	 *
-	 * @param headers the basic {@link MultiMap Vert.x headers} that should be wrapped into the header information
-	 * @return new header information with the wrapped {@link MultiMap Vert.x headers}
+	 * @param headers the {@link MultiMap Vert.x headers} you want to wrap into the {@link HeaderInformation} object
+	 * @return a new {@link HeaderInformation} object with the wrapped {@link MultiMap Vert.x headers}
 	 */
 	public static HeaderInformation from(MultiMap headers) {
 		return new HeaderInformation(headers);
 	}
 
 	/**
-	 * Creates new header information from existing {@link Message Vert.x message}.
+	 * Creates a new {@link HeaderInformation} object from a {@link Message Vert.x message}.
 	 *
-	 * @param message the received {@link Message Vert.x message} which contains the received headers
-	 * @return new header information with the received headers from the {@link Message Vert.x message}
+	 * @param message the {@link Message Vert.x message} that contains the {@link MultiMap Vert.x headers}
+	 *                you want to wrap into the {@link HeaderInformation} object
+	 * @return a new {@link HeaderInformation} object with the {@link MultiMap Vert.x headers}
+	 * from the {@link Message Vert.x message}
 	 */
 	public static HeaderInformation from(Message<?> message) {
 		return new HeaderInformation(message);
 	}
 
 	/**
-	 * Creates new header information from existing {@link DeliveryOptions}.
+	 * Creates a new {@link HeaderInformation} object from {@link DeliveryOptions}.
 	 *
-	 * @param options existing {@link DeliveryOptions} which contain the basic {@link MultiMap Vert.x headers}
-	 * @return new header information with the headers from the {@link DeliveryOptions}
+	 * @param options {@link DeliveryOptions} that contain the {@link MultiMap Vert.x headers}
+	 *                you want to wrap into the {@link HeaderInformation} object
+	 * @return a new {@link HeaderInformation} object with the {@link MultiMap Vert.x headers}
+	 * from the {@link DeliveryOptions}
 	 */
 	public static HeaderInformation from(DeliveryOptions options) {
 		return new HeaderInformation(options);
 	}
 
 	/**
-	 * Creates new header information with empty headers.
+	 * Creates a new {@link HeaderInformation} object with empty headers.
 	 *
 	 * @see MultiMap#caseInsensitiveMultiMap()
 	 */
@@ -124,61 +125,61 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Creates new header information with the provided {@link MultiMap Vert.x headers}.
+	 * Creates a new {@link HeaderInformation} object with the provided {@link MultiMap Vert.x headers}.
 	 *
-	 * @param headers the basic {@link MultiMap Vert.x headers} that should be wrapped inside the header information
+	 * @param headers the {@link MultiMap Vert.x headers} that you want to wrap inside
+	 *                the {@link HeaderInformation} object
 	 */
 	public HeaderInformation(MultiMap headers) {
 		this.headers = headers;
 	}
 
 	/**
-	 * Creates new header information with the headers from the given {@link Message Vert.x message}.
+	 * Creates a new {@link HeaderInformation} object with the headers from the {@link Message Vert.x message}.
 	 *
-	 * @param message the {@link Message Vert.x message} that contains the basic {@link MultiMap Vert.x headers}
-	 *                which should be wrapped inside the header information
+	 * @param message the {@link Message Vert.x message} that contains the {@link MultiMap Vert.x headers}
+	 *                which you want to wrap inside the {@link HeaderInformation} object
 	 */
 	public HeaderInformation(Message<?> message) {
 		this(message.headers());
 	}
 
 	/**
-	 * Creates new header information with the headers from the given {@link DeliveryOptions}.
+	 * Creates a new {@link HeaderInformation} object with the headers from the {@link DeliveryOptions}.
 	 *
-	 * @param options the {@link DeliveryOptions} that contain the basic {@link MultiMap Vert.x headers}
-	 *                which should be wrapped inside the header information
+	 * @param options the {@link DeliveryOptions} that contain the {@link MultiMap Vert.x headers}
+	 *                which you want to wrap inside the {@link HeaderInformation} object
 	 */
 	public HeaderInformation(DeliveryOptions options) {
 		this(options.getHeaders());
 	}
 
 	/**
-	 * Returns the wrapped basic {@link MultiMap Vert.x headers} ready to use in {@link DeliveryOptions}
+	 * Returns the wrapped {@link MultiMap Vert.x headers} ready to use in {@link DeliveryOptions}
 	 * or the {@link de.wuespace.telestion.api.verticle.trait.WithEventBus WithEventBus} verticle trait.
 	 *
-	 * @return the wrapped basic {@link MultiMap Vert.x headers}
+	 * @return the wrapped {@link MultiMap Vert.x headers}
 	 */
 	public MultiMap getHeaders() {
 		return headers;
 	}
 
 	/**
-	 * Attaches the wrapped basic {@link MultiMap Vert.x headers} to the given {@link DeliveryOptions}
+	 * Attaches the wrapped {@link MultiMap Vert.x headers} to the {@link DeliveryOptions}
 	 * and return them again for further usage.
 	 *
-	 * @param options the {@link DeliveryOptions} on which the wrapped basic {@link MultiMap Vert.x headers}
-	 *                should be attached
-	 * @return the given {@link DeliveryOptions} for further usage
+	 * @param options the {@link DeliveryOptions} that receive the wrapped {@link MultiMap Vert.x headers}
+	 * @return the {@link DeliveryOptions} for further usage
 	 */
 	public DeliveryOptions attach(DeliveryOptions options) {
 		return options.setHeaders(headers);
 	}
 
 	/**
-	 * Creates new and empty {@link DeliveryOptions} and attaches the wrapped basic {@link MultiMap Vert.x headers}
+	 * Creates new and empty {@link DeliveryOptions} and attaches the wrapped {@link MultiMap Vert.x headers}
 	 * to them.
 	 *
-	 * @return the new {@link DeliveryOptions} with the attached basic {@link MultiMap Vert.x headers}
+	 * @return the new {@link DeliveryOptions} with the attached {@link MultiMap Vert.x headers}
 	 */
 	public DeliveryOptions toOptions() {
 		return attach(new DeliveryOptions());
@@ -189,11 +190,11 @@ public class HeaderInformation {
 	///
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers}.
-	 * If no value in the key slot is found, an {@link Optional#empty() empty Optional} is returned instead.
+	 * Returns the first stored value assigned to the key as {@link String}.
+	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<String> get(String key) {
@@ -201,12 +202,12 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers}.
-	 * If no value in the key slot is found, the default value is used instead.
+	 * Returns the first stored value assigned to the key as {@link String}.
+	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value in the key slot is found
-	 * @return the value in the key slot or the default value if the key slot is empty
+	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
 	public String get(String key, String defaultValue) {
@@ -214,12 +215,11 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a byte.
-	 * If no value in the key slot is found or the value cannot be converted to a byte,
-	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 * Returns the first stored value assigned to the key as {@link Byte}.
+	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the value as a byte wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Byte> getByte(String key) {
@@ -227,14 +227,12 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a byte.
-	 * If no value in the key slot is found ir the value cannot be converted to a byte,
-	 * the default value is used instead.
+	 * Returns the first stored value assigned to the key as {@link Byte}.
+	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value in the key slot is found
-	 *                     or the value in the key slot is not parsable
-	 * @return the value in the key slot as a byte or the default value if the key slot is empty
+	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
 	public byte getByte(String key, byte defaultValue) {
@@ -242,12 +240,11 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as an integer.
-	 * If no value in the key slot is found or the value cannot be converted to an integer,
-	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 * Returns the first stored value assigned to the key as {@link Integer}.
+	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the value as an integer wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Integer> getInt(String key) {
@@ -255,14 +252,12 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as an integer.
-	 * If no value in the key slot is found ir the value cannot be converted to an integer,
-	 * the default value is used instead.
+	 * Returns the first stored value assigned to the key as {@link Integer}.
+	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value in the key slot is found
-	 *                     or the value in the key slot is not parsable
-	 * @return the value in the key slot as an integer or the default value if the key slot is empty
+	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
 	public int getInt(String key, int defaultValue) {
@@ -270,12 +265,11 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a long.
-	 * If no value in the key slot is found or the value cannot be converted to a long,
-	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 * Returns the first stored value assigned to the key as {@link Long}.
+	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the value as a long wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Long> getLong(String key) {
@@ -283,14 +277,12 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a long.
-	 * If no value in the key slot is found ir the value cannot be converted to a long,
-	 * the default value is used instead.
+	 * Returns the first stored value assigned to the key as {@link Long}.
+	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value in the key slot is found
-	 *                     or the value in the key slot is not parsable
-	 * @return the value in the key slot as a long or the default value if the key slot is empty
+	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
 	public long getLong(String key, long defaultValue) {
@@ -298,12 +290,11 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a float.
-	 * If no value in the key slot is found or the value cannot be converted to a float,
-	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 * Returns the first stored value assigned to the key as {@link Float}.
+	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the value as a float wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Float> getFloat(String key) {
@@ -311,14 +302,12 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a float.
-	 * If no value in the key slot is found ir the value cannot be converted to a float,
-	 * the default value is used instead.
+	 * Returns the first stored value assigned to the key as {@link Float}.
+	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value in the key slot is found
-	 *                     or the value in the key slot is not parsable
-	 * @return the value in the key slot as a float or the default value if the key slot is empty
+	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
 	public float getFloat(String key, float defaultValue) {
@@ -326,12 +315,11 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a double.
-	 * If no value in the key slot is found or the value cannot be converted to a double,
-	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 * Returns the first stored value assigned to the key as {@link Double}.
+	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the value as a double wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Double> getDouble(String key) {
@@ -339,14 +327,12 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a double.
-	 * If no value in the key slot is found ir the value cannot be converted to a double,
-	 * the default value is used instead.
+	 * Returns the first stored value assigned to the key as {@link Double}.
+	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value in the key slot is found
-	 *                     or the value in the key slot is not parsable
-	 * @return the value in the key slot as a double or the default value if the key slot is empty
+	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
 	public double getDouble(String key, double defaultValue) {
@@ -354,12 +340,11 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a character.
-	 * If no value in the key slot is found or the value cannot be converted to a character,
-	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 * Returns the first stored value assigned to the key as {@link Character}.
+	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the value as a character wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Character> getChar(String key) {
@@ -367,14 +352,12 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a character.
-	 * If no value in the key slot is found ir the value cannot be converted to a character,
-	 * the default value is used instead.
+	 * Returns the first stored value assigned to the key as {@link Character}.
+	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value in the key slot is found
-	 *                     or the value in the key slot is not parsable
-	 * @return the value in the key slot as a character or the default value if the key slot is empty
+	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
 	public char getChar(String key, char defaultValue) {
@@ -382,12 +365,11 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a boolean.
-	 * If no value in the key slot is found or the value cannot be converted to a boolean,
-	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 * Returns the first stored value assigned to the key as {@link Boolean}.
+	 * If no value is assigned to the key, an {@link Optional#empty() empty Optional} is returned instead.
 	 *
 	 * @param key the key to which the value is assigned
-	 * @return the value as a boolean wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @return the first stored value wrapped inside a {@link Optional} for better {@code null} type safety
 	 * @see MultiMap#get(String)
 	 */
 	public Optional<Boolean> getBoolean(String key) {
@@ -395,14 +377,12 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a character.
-	 * If no value in the key slot is found ir the value cannot be converted to a character,
-	 * the default value is used instead.
+	 * Returns the first stored value assigned to the key as {@link Boolean}.
+	 * If no value is assigned to the key, the default value is used instead.
 	 *
 	 * @param key          the key to which the value is assigned
-	 * @param defaultValue the value which are returned if no value in the key slot is found
-	 *                     or the value in the key slot is not parsable
-	 * @return the value in the key slot as a character or the default value if the key slot is empty
+	 * @param defaultValue the value which are returned if no value is assigned to the key
+	 * @return the first stored value or the default value if no value is assigned to the key
 	 * @see MultiMap#get(String)
 	 */
 	public boolean getBoolean(String key, boolean defaultValue) {
@@ -410,10 +390,10 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns a list of all stored values in the specified key slot of the wrapped {@link MultiMap Vert.x headers}.
+	 * Returns a list of all stored values assigned to the key as a list of {@link String Strings}.
 	 *
 	 * @param key the key to which the values are assigned
-	 * @return the stored values as a list or an empty list if no values are stored
+	 * @return all stored values as a list of {@link String Strings}
 	 * @see MultiMap#getAll(String)
 	 */
 	public List<String> getAll(String key) {
@@ -425,290 +405,114 @@ public class HeaderInformation {
 	///
 
 	/**
-	 * Adds multiple strings to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 * Appends multiple {@link String} values assigned to the key.
 	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new strings that should be added to the key slot
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link String} values that you want to append to the key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#add(String, Iterable)
 	 */
 	public HeaderInformation add(String key, String... values) {
-		return add(key, List.of(values));
+		return add(key, Arrays.stream(values));
 	}
 
 	/**
-	 * Adds multiple characters to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 * Appends multiple {@link Character} values assigned to the key.
 	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new characters that should be added to the key slot
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Character} values that you want to append to the key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#add(String, Iterable)
 	 */
 	public HeaderInformation add(String key, Character... values) {
-		return add(key, Stream.of(values).map(String::valueOf).toList());
+		return add(key, Arrays.stream(values).map(String::valueOf));
 	}
 
 	/**
-	 * Adds multiple integers to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 * Appends multiple {@link Integer} values assigned to the key.
 	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new integers that should be added to the key slot
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Integer} values that you want to append to the key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#add(String, Iterable)
 	 */
 	public HeaderInformation add(String key, Integer... values) {
-		return add(key, Stream.of(values).map(String::valueOf).toList());
+		return add(key, Arrays.stream(values).map(String::valueOf));
 	}
 
 	/**
-	 * Adds multiple longs to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 * Appends multiple {@link Long} values assigned to the key.
 	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new longs that should be added to the key slot
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Long} values that you want to append to the key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#add(String, Iterable)
 	 */
 	public HeaderInformation add(String key, Long... values) {
-		return add(key, Stream.of(values).map(String::valueOf).toList());
+		return add(key, Arrays.stream(values).map(String::valueOf));
 	}
 
 	/**
-	 * Adds multiple shorts to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 * Appends multiple {@link Short} values assigned to the key.
 	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new shorts that should be added to the key slot
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Short} values that you want to append to the key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#add(String, Iterable)
 	 */
 	public HeaderInformation add(String key, Short... values) {
-		return add(key, Stream.of(values).map(String::valueOf).toList());
+		return add(key, Arrays.stream(values).map(String::valueOf));
 	}
 
 	/**
-	 * Adds multiple bytes to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 * Appends multiple {@link Byte} values assigned to the key.
 	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new bytes that should be added to the key slot
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Byte} values that you want to append to the key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#add(String, Iterable)
 	 */
 	public HeaderInformation add(String key, Byte... values) {
-		return add(key, Stream.of(values).map(String::valueOf).toList());
+		return add(key, Arrays.stream(values).map(String::valueOf));
 	}
 
 	/**
-	 * Adds multiple doubles to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 * Appends multiple {@link Double} values assigned to the key.
 	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new doubles that should be added to the key slot
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Double} values that you want to append to the key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#add(String, Iterable)
 	 */
 	public HeaderInformation add(String key, Double... values) {
-		return add(key, Stream.of(values).map(String::valueOf).toList());
+		return add(key, Arrays.stream(values).map(String::valueOf));
 	}
 
 	/**
-	 * Adds multiple booleans to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 * Appends multiple {@link Boolean} values assigned to the key.
 	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new booleans that should be added to the key slot
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Boolean} values that you want to append to the key
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#add(String, Iterable)
 	 */
 	public HeaderInformation add(String key, Boolean... values) {
-		return add(key, Stream.of(values).map(String::valueOf).toList());
+		return add(key, Arrays.stream(values).map(String::valueOf));
 	}
 
 	/**
-	 * Intermediate step to add a list of strings to the wrapped {@link MultiMap Vert.x headers}.
+	 * Intermediate step to append a stream of strings to the wrapped {@link MultiMap Vert.x headers}.
 	 */
-	private HeaderInformation add(String key, List<String> list) {
-		headers.add(key, list);
-		return this;
-	}
-
-	///
-	/// SET METHODS
-	///
-
-	/**
-	 * Sets multiple strings in the specified key slot of the {@link MultiMap Vert.x headers}
-	 * and replaces potentially existing values.
-	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new strings that should be replaced in the key slot
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#set(String, Iterable)
-	 */
-	public HeaderInformation set(String key, String... values) {
-		return set(key, List.of(values));
-	}
-
-	/**
-	 * Sets multiple characters in the specified key slot of the {@link MultiMap Vert.x headers}
-	 * and replaces potentially existing values.
-	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new characters that should be replaced in the key slot
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#set(String, Iterable)
-	 */
-	public HeaderInformation set(String key, Character... values) {
-		return set(key, Stream.of(values).map(String::valueOf).toList());
-	}
-
-	/**
-	 * Sets multiple integers in the specified key slot of the {@link MultiMap Vert.x headers}
-	 * and replaces potentially existing values.
-	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new integers that should be replaced in the key slot
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#set(String, Iterable)
-	 */
-	public HeaderInformation set(String key, Integer... values) {
-		return set(key, Stream.of(values).map(String::valueOf).toList());
-	}
-
-	/**
-	 * Sets multiple longs in the specified key slot of the {@link MultiMap Vert.x headers}
-	 * and replaces potentially existing values.
-	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new longs that should be replaced in the key slot
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#set(String, Iterable)
-	 */
-	public HeaderInformation set(String key, Long... values) {
-		return set(key, Stream.of(values).map(String::valueOf).toList());
-	}
-
-	/**
-	 * Sets multiple shorts in the specified key slot of the {@link MultiMap Vert.x headers}
-	 * and replaces potentially existing values.
-	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new shorts that should be replaced in the key slot
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#set(String, Iterable)
-	 */
-	public HeaderInformation set(String key, Short... values) {
-		return set(key, Stream.of(values).map(String::valueOf).toList());
-	}
-
-	/**
-	 * Sets multiple bytes in the specified key slot of the {@link MultiMap Vert.x headers}
-	 * and replaces potentially existing values.
-	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new bytes that should be replaced in the key slot
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#set(String, Iterable)
-	 */
-	public HeaderInformation set(String key, Byte... values) {
-		return set(key, Stream.of(values).map(String::valueOf).toList());
-	}
-
-	/**
-	 * Sets multiple doubles in the specified key slot of the {@link MultiMap Vert.x headers}
-	 * and replaces potentially existing values.
-	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new doubles that should be replaced in the key slot
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#set(String, Iterable)
-	 */
-	public HeaderInformation set(String key, Double... values) {
-		return set(key, Stream.of(values).map(String::valueOf).toList());
-	}
-
-	/**
-	 * Sets multiple floats in the specified key slot of the {@link MultiMap Vert.x headers}
-	 * and replaces potentially existing values.
-	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new floats that should be replaced in the key slot
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#set(String, Iterable)
-	 */
-	public HeaderInformation set(String key, Float... values) {
-		return set(key, Stream.of(values).map(String::valueOf).toList());
-	}
-
-	/**
-	 * Sets multiple booleans in the specified key slot of the {@link MultiMap Vert.x headers}
-	 * and replaces potentially existing values.
-	 *
-	 * @param key    the key to which the value is assigned
-	 * @param values the new booleans that should be replaced in the key slot
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#set(String, Iterable)
-	 */
-	public HeaderInformation set(String key, Boolean... values) {
-		return set(key, Stream.of(values).map(String::valueOf).toList());
-	}
-
-	/**
-	 * Intermediate step to set a list of strings in the wrapped {@link MultiMap Vert.x headers}.
-	 */
-	private HeaderInformation set(String key, List<String> values) {
-		headers.set(key, values);
-		return this;
-	}
-
-	///
-	/// OTHER METHODS FROM MULTIMAP
-	///
-
-	/**
-	 * Replaces all key slots of the wrapped {@link MultiMap Vert.x headers} with the specified ones.
-	 * All other existing key slots are cleared.
-	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
-	 *
-	 * @param headers the {@link MultiMap Vert.x headers} that contains the new key slots and associated values
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#setAll(MultiMap)
-	 */
-	public HeaderInformation setAll(MultiMap headers) {
-		this.headers.setAll(headers);
+	private HeaderInformation add(String key, Stream<String> stream) {
+		headers.add(key, stream.toList());
 		return this;
 	}
 
 	/**
-	 * Replaces all key slots of the wrapped {@link MultiMap Vert.x headers} with the specified ones.
-	 * All other existing key slots are cleared.
-	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 * Appends all values assigned to their keys from the {@link MultiMap} to already existing values.
 	 *
-	 * @param headers a {@link Map} that contains the new key slots and associated values
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#setAll(Map)
-	 */
-	public HeaderInformation setAll(Map<String, String> headers) {
-		this.headers.setAll(headers);
-		return this;
-	}
-
-	/**
-	 * Replaces all key slots of the wrapped {@link MultiMap Vert.x headers}
-	 * with the wrapped {@link MultiMap Vert.x headers} of the specified instance.
-	 * All other existing key slots are cleared.
-	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
-	 *
-	 * @param information the other {@link HeaderInformation} instance that contains the new key slots
-	 *                    and associated values
-	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see HeaderInformation#setAll(MultiMap)
-	 */
-	public HeaderInformation setAll(HeaderInformation information) {
-		return setAll(information.headers);
-	}
-
-	/**
-	 * Adds all key slots and values of the specified {@link MultiMap Vert.x headers}
-	 * to the wrapped {@link MultiMap Vert.x headers}.
-	 *
-	 * @param headers the {@link MultiMap Vert.x headers} that contain the new key slots and values
+	 * @param headers the {@link MultiMap} that contain the new values
+	 *                which you want to append to the existing values
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#addAll(MultiMap)
 	 */
@@ -718,9 +522,10 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Adds all key slots and values of the specified {@link Map} to the wrapped {@link MultiMap Vert.x headers}.
+	 * Appends all values assigned to their keys from the {@link Map} to already existing values.
 	 *
-	 * @param headers the {@link Map} that contain the new key slots and values
+	 * @param headers the {@link Map} that contain the new values
+	 *                which you want to append to the existing values
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#addAll(Map)
 	 */
@@ -730,11 +535,10 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Adds all key slots and values of the specified {@link HeaderInformation} instance
-	 * to the wrapped {@link MultiMap Vert.x headers}.
+	 * Appends all values assigned to their keys from the {@link HeaderInformation} object to already existing values.
 	 *
-	 * @param information the other {@link HeaderInformation} instance that contains the new key slots
-	 *                    and associated values
+	 * @param information the {@link HeaderInformation} object that contain the new values
+	 *                    which you want to append to the existing values
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#addAll(MultiMap)
 	 */
@@ -742,20 +546,197 @@ public class HeaderInformation {
 		return addAll(information.headers);
 	}
 
+	///
+	/// SET METHODS
+	///
+
 	/**
-	 * Removes all values from the specified key slot on the wrapped {@link MultiMap Vert.x headers}.
+	 * Replaces multiple {@link String} values with the old allocation assigned to the key .
 	 *
-	 * @param name the key to which the values are assigned
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link String} values that you want to replace with the old allocation
 	 * @return a reference to {@code this}, so the API can be used fluently
-	 * @see MultiMap#remove(String)
+	 * @see MultiMap#set(String, Iterable)
 	 */
-	public HeaderInformation remove(String name) {
-		headers.remove(name);
+	public HeaderInformation set(String key, String... values) {
+		return set(key, Arrays.stream(values));
+	}
+
+	/**
+	 * Replaces multiple {@link Character} values with the old allocation assigned to the key.
+	 *
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Character} values that you want to replace with the old allocation
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Character... values) {
+		return set(key, Arrays.stream(values).map(String::valueOf));
+	}
+
+	/**
+	 * Replaces multiple {@link Integer} values with the old allocation assigned to the key.
+	 *
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Integer} values that you want to replace with the old allocation
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Integer... values) {
+		return set(key, Arrays.stream(values).map(String::valueOf));
+	}
+
+	/**
+	 * Replaces multiple {@link Long} values with the old allocation assigned to the key.
+	 *
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Long} values that you want to replace with the old allocation
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Long... values) {
+		return set(key, Arrays.stream(values).map(String::valueOf));
+	}
+
+	/**
+	 * Replaces multiple {@link Short} values with the old allocation assigned to the key.
+	 *
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Short} values that you want to replace with the old allocation
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Short... values) {
+		return set(key, Arrays.stream(values).map(String::valueOf));
+	}
+
+	/**
+	 * Replaces multiple {@link Byte} values with the old allocation assigned to the key.
+	 *
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Byte} values that you want to replace with the old allocation
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Byte... values) {
+		return set(key, Arrays.stream(values).map(String::valueOf));
+	}
+
+	/**
+	 * Replaces multiple {@link Double} values with the old allocation assigned to the key.
+	 *
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Double} values that you want to replace with the old allocation
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Double... values) {
+		return set(key, Arrays.stream(values).map(String::valueOf));
+	}
+
+	/**
+	 * Replaces multiple {@link Float} values with the old allocation assigned to the key.
+	 *
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Float} values that you want to replace with the old allocation
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Float... values) {
+		return set(key, Arrays.stream(values).map(String::valueOf));
+	}
+
+	/**
+	 * Replaces multiple {@link Boolean} values with the old allocation assigned to the key.
+	 *
+	 * @param key    the key to which the values are assigned
+	 * @param values the new {@link Boolean} values that you want to replace with the old allocation
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Boolean... values) {
+		return set(key, Arrays.stream(values).map(String::valueOf));
+	}
+
+	/**
+	 * Intermediate step to replace a stream of strings with the old allocation
+	 * in the wrapped {@link MultiMap Vert.x headers}.
+	 */
+	private HeaderInformation set(String key, Stream<String> stream) {
+		headers.set(key, stream.toList());
 		return this;
 	}
 
 	/**
-	 * Clears all key slots and values from the wrapped {@link MultiMap Vert.x headers}.
+	 * Replaces all values assigned to their keys with the content of the {@link MultiMap}.
+	 * All remaining values are cleared.
+	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 *
+	 * @param headers the {@link MultiMap} that contains the new values assigned to their keys
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#setAll(MultiMap)
+	 */
+	public HeaderInformation setAll(MultiMap headers) {
+		this.headers.setAll(headers);
+		return this;
+	}
+
+	/**
+	 * Replaces all values assigned to their keys with the content of the {@link Map}.
+	 * All remaining values are cleared.
+	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 *
+	 * @param headers the {@link Map} that contains the new values assigned to their keys
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#setAll(Map)
+	 */
+	public HeaderInformation setAll(Map<String, String> headers) {
+		this.headers.setAll(headers);
+		return this;
+	}
+
+	/**
+	 * Replaces all values assigned to their keys with the content of the {@link HeaderInformation} object.
+	 * All other existing key slots are cleared.
+	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 *
+	 * @param information the {@link HeaderInformation} object that contains the new values assigned to their keys
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see HeaderInformation#setAll(MultiMap)
+	 */
+	public HeaderInformation setAll(HeaderInformation information) {
+		return setAll(information.headers);
+	}
+
+	///
+	/// OTHER METHODS FROM MULTIMAP
+	///
+
+	/**
+	 * Returns {@code true}, if at least one value is assigned to the key.
+	 * If no value is assigned, {@code false} is returned instead.
+	 *
+	 * @param key the key to which the value can be assigned
+	 * @return {@code true}, if at least one value is assigned to the key
+	 */
+	public boolean contains(String key) {
+		return headers.contains(key);
+	}
+
+	/**
+	 * Removes all values assigned to the key.
+	 *
+	 * @param key the key to which the values are assigned
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#remove(String)
+	 */
+	public HeaderInformation remove(String key) {
+		headers.remove(key);
+		return this;
+	}
+
+	/**
+	 * Clears all values assigned to their keys.
 	 *
 	 * @return a reference to {@code this}, so the API can be used fluently
 	 * @see MultiMap#clear()
@@ -766,9 +747,9 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns the number of currently used key slots in the wrapped {@link MultiMap Vert.x headers}.
+	 * Returns the number of all keys which have values assigned to.
 	 *
-	 * @return the number of used key slots in the {@link MultiMap Vert.x headers}
+	 * @return the number of all keys which have values assigned to
 	 * @see MultiMap#size()
 	 */
 	public int size() {
@@ -776,9 +757,9 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns an immutable set of all keys currently used in the wrapped {@link MultiMap Vert.x headers}.
+	 * Returns an immutable set of all keys which have values assigned to.
 	 *
-	 * @return an immutable set of all keys in the wrapped {@link MultiMap Vert.x headers}
+	 * @return an immutable set of all keys which have values assigned to
 	 * @see MultiMap#names()
 	 */
 	public Set<String> names() {
@@ -786,9 +767,9 @@ public class HeaderInformation {
 	}
 
 	/**
-	 * Returns {@code true}, if the wrapped {@link MultiMap Vert.x headers} has no entries.
+	 * Returns {@code true}, if the wrapped {@link MultiMap Vert.x headers} have no entries.
 	 *
-	 * @return returns {@code true} if the wrapped {@link MultiMap Vert.x headers} has no entries
+	 * @return returns {@code true} if the wrapped {@link MultiMap Vert.x headers} have no entries
 	 * @see MultiMap#isEmpty()
 	 */
 	public boolean isEmpty() {
@@ -801,9 +782,11 @@ public class HeaderInformation {
 	 */
 	private final MultiMap headers;
 
+	private static final Logger logger = LoggerFactory.getLogger(HeaderInformation.class);
+
 	/**
 	 * Wraps the specified function into a {@link NumberFormatException} try-catch block
-	 * to prevent exception breakout in the parsing steps above.
+	 * to prevent exception breakout in the parsing steps.
 	 * If the value cannot be parsed, {@code null} is returned instead.
 	 *
 	 * @param func the function that can throw a {@link NumberFormatException} during parsing

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
@@ -521,7 +521,7 @@ public class HeaderInformation {
 
 		if (contains(key)) {
 			var existing = getAll(key);
-			logger.warn("The header information object already contains values assigned to that key. " +
+			logger.debug("The header information object already contains values assigned to that key. " +
 							"Appending new values to existing values. Key: {}, Before: {}, Now: {}",
 					key, existing, Stream.of(existing, list).toList());
 		}
@@ -706,7 +706,7 @@ public class HeaderInformation {
 
 		if (contains(key)) {
 			var existing = getAll(key);
-			logger.warn("The header information object already contains values assigned to that key. " +
+			logger.debug("The header information object already contains values assigned to that key. " +
 					"Overriding existing values with new values. Key: {}, Before: {}, Now: {}", key, existing, list);
 		}
 

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/HeaderInformation.java
@@ -1,0 +1,823 @@
+package de.wuespace.telestion.api.message;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * <h2>Description</h2>
+ *
+ * <p>
+ * Header information are useful to attach simple information to messages
+ * that should be transferred over the Vert.x event bus.
+ * <p>
+ * This implementation extends the already existing functionality
+ * of the {@link Message Vert.x message} {@link MultiMap headers}
+ * to allow storing and retrieving of other basic data types than {@link String}.
+ * <p>
+ * There are numerous interfaces that simplifies the usage with the existing features of Vert.x
+ * and better support through the {@link de.wuespace.telestion.api.verticle.trait.WithEventBus WithEventBus trait}
+ * for {@link io.vertx.core.Verticle Vert.x verticles}
+ * and especially the {@link de.wuespace.telestion.api.verticle.TelestionVerticle TelestionVerticle}.
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ * {@code
+ * public class MyVerticle extends TelestionVerticle<GenericConfiguration> implements WithEventBus {
+ *     @Override
+ *     public void onStart() {
+ *         var requestInfos = new HeaderInformation()
+ *                 .add("version", 1)
+ *                 .add("log-enabled", true)
+ *                 .add("my-initial-char", 'C').
+ *                 .add("my-coworkers-name", "fussel178");
+ *
+ *         request("request-address", "Hello with Info", requestInfos).onSuccess(message -> {
+ *             var responseInfos = HeaderInformation.from(message);
+ *
+ *             logger.info("Received version: {}", responseInfos.getInt("version", -1));
+ *             logger.info("Received log enabled state: {}", responseInfos.getBoolean("log-enabled", false));
+ *             logger.info("Received initial char: {}", responseInfos.getChar("my-initial-char", '\0'));
+ *             logger.info("Received coworker name: {}", responseInfos.get("my-coworkers-name", "unset"));
+ *         });
+ *     }
+ * }
+ * }
+ * </pre>
+ *
+ * @author Cedric Boes (@cb0s), Ludwig Richter (@fussel178)
+ */
+public class HeaderInformation {
+
+	/**
+	 * Merges an array of header information into one header information object.
+	 *
+	 * @param information multiple header information that should be merged into one
+	 * @return the merged header information
+	 */
+	public static HeaderInformation merge(HeaderInformation... information) {
+		return merge(Arrays.stream(information));
+	}
+
+	/**
+	 * Merges a list of header information into one header information object.
+	 *
+	 * @param list multiple header information that should be merged into one
+	 * @return the merged header information
+	 */
+	public static HeaderInformation merge(List<HeaderInformation> list) {
+		return merge(list.stream());
+	}
+
+	/**
+	 * Merges a stream of header information into one header information object.
+	 *
+	 * @param stream a stream that contains multiple header information that should be merged into one
+	 * @return the merged header information
+	 */
+	public static HeaderInformation merge(Stream<HeaderInformation> stream) {
+		var headers = stream.map(HeaderInformation::getHeaders);
+		return new HeaderInformation(MultiMapUtils.merge(headers));
+	}
+
+	/**
+	 * Creates new header information from existing {@link MultiMap Vert.x headers}.
+	 *
+	 * @param headers the basic {@link MultiMap Vert.x headers} that should be wrapped into the header information
+	 * @return new header information with the wrapped {@link MultiMap Vert.x headers}
+	 */
+	public static HeaderInformation from(MultiMap headers) {
+		return new HeaderInformation(headers);
+	}
+
+	/**
+	 * Creates new header information from existing {@link Message Vert.x message}.
+	 *
+	 * @param message the received {@link Message Vert.x message} which contains the received headers
+	 * @return new header information with the received headers from the {@link Message Vert.x message}
+	 */
+	public static HeaderInformation from(Message<?> message) {
+		return new HeaderInformation(message);
+	}
+
+	/**
+	 * Creates new header information from existing {@link DeliveryOptions}.
+	 *
+	 * @param options existing {@link DeliveryOptions} which contain the basic {@link MultiMap Vert.x headers}
+	 * @return new header information with the headers from the {@link DeliveryOptions}
+	 */
+	public static HeaderInformation from(DeliveryOptions options) {
+		return new HeaderInformation(options);
+	}
+
+	/**
+	 * Creates new header information with empty headers.
+	 *
+	 * @see MultiMap#caseInsensitiveMultiMap()
+	 */
+	public HeaderInformation() {
+		this(MultiMap.caseInsensitiveMultiMap());
+	}
+
+	/**
+	 * Creates new header information with the provided {@link MultiMap Vert.x headers}.
+	 *
+	 * @param headers the basic {@link MultiMap Vert.x headers} that should be wrapped inside the header information
+	 */
+	public HeaderInformation(MultiMap headers) {
+		this.headers = headers;
+	}
+
+	/**
+	 * Creates new header information with the headers from the given {@link Message Vert.x message}.
+	 *
+	 * @param message the {@link Message Vert.x message} that contains the basic {@link MultiMap Vert.x headers}
+	 *                which should be wrapped inside the header information
+	 */
+	public HeaderInformation(Message<?> message) {
+		this(message.headers());
+	}
+
+	/**
+	 * Creates new header information with the headers from the given {@link DeliveryOptions}.
+	 *
+	 * @param options the {@link DeliveryOptions} that contain the basic {@link MultiMap Vert.x headers}
+	 *                which should be wrapped inside the header information
+	 */
+	public HeaderInformation(DeliveryOptions options) {
+		this(options.getHeaders());
+	}
+
+	/**
+	 * Returns the wrapped basic {@link MultiMap Vert.x headers} ready to use in {@link DeliveryOptions}
+	 * or the {@link de.wuespace.telestion.api.verticle.trait.WithEventBus WithEventBus} verticle trait.
+	 *
+	 * @return the wrapped basic {@link MultiMap Vert.x headers}
+	 */
+	public MultiMap getHeaders() {
+		return headers;
+	}
+
+	/**
+	 * Attaches the wrapped basic {@link MultiMap Vert.x headers} to the given {@link DeliveryOptions}
+	 * and return them again for further usage.
+	 *
+	 * @param options the {@link DeliveryOptions} on which the wrapped basic {@link MultiMap Vert.x headers}
+	 *                should be attached
+	 * @return the given {@link DeliveryOptions} for further usage
+	 */
+	public DeliveryOptions attach(DeliveryOptions options) {
+		return options.setHeaders(headers);
+	}
+
+	/**
+	 * Creates new and empty {@link DeliveryOptions} and attaches the wrapped basic {@link MultiMap Vert.x headers}
+	 * to them.
+	 *
+	 * @return the new {@link DeliveryOptions} with the attached basic {@link MultiMap Vert.x headers}
+	 */
+	public DeliveryOptions toOptions() {
+		return attach(new DeliveryOptions());
+	}
+
+	///
+	/// GET METHODS
+	///
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers}.
+	 * If no value in the key slot is found, an {@link Optional#empty() empty Optional} is returned instead.
+	 *
+	 * @param key the key to which the value is assigned
+	 * @return the value wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @see MultiMap#get(String)
+	 */
+	public Optional<String> get(String key) {
+		return Optional.ofNullable(headers.get(key));
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers}.
+	 * If no value in the key slot is found, the default value is used instead.
+	 *
+	 * @param key          the key to which the value is assigned
+	 * @param defaultValue the value which are returned if no value in the key slot is found
+	 * @return the value in the key slot or the default value if the key slot is empty
+	 * @see MultiMap#get(String)
+	 */
+	public String get(String key, String defaultValue) {
+		return get(key).orElse(defaultValue);
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a byte.
+	 * If no value in the key slot is found or the value cannot be converted to a byte,
+	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 *
+	 * @param key the key to which the value is assigned
+	 * @return the value as a byte wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @see MultiMap#get(String)
+	 */
+	public Optional<Byte> getByte(String key) {
+		return get(key).map(safeParse(Byte::parseByte));
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a byte.
+	 * If no value in the key slot is found ir the value cannot be converted to a byte,
+	 * the default value is used instead.
+	 *
+	 * @param key          the key to which the value is assigned
+	 * @param defaultValue the value which are returned if no value in the key slot is found
+	 *                     or the value in the key slot is not parsable
+	 * @return the value in the key slot as a byte or the default value if the key slot is empty
+	 * @see MultiMap#get(String)
+	 */
+	public byte getByte(String key, byte defaultValue) {
+		return getByte(key).orElse(defaultValue);
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as an integer.
+	 * If no value in the key slot is found or the value cannot be converted to an integer,
+	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 *
+	 * @param key the key to which the value is assigned
+	 * @return the value as an integer wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @see MultiMap#get(String)
+	 */
+	public Optional<Integer> getInt(String key) {
+		return get(key).map(safeParse(Integer::parseInt));
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as an integer.
+	 * If no value in the key slot is found ir the value cannot be converted to an integer,
+	 * the default value is used instead.
+	 *
+	 * @param key          the key to which the value is assigned
+	 * @param defaultValue the value which are returned if no value in the key slot is found
+	 *                     or the value in the key slot is not parsable
+	 * @return the value in the key slot as an integer or the default value if the key slot is empty
+	 * @see MultiMap#get(String)
+	 */
+	public int getInt(String key, int defaultValue) {
+		return getInt(key).orElse(defaultValue);
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a long.
+	 * If no value in the key slot is found or the value cannot be converted to a long,
+	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 *
+	 * @param key the key to which the value is assigned
+	 * @return the value as a long wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @see MultiMap#get(String)
+	 */
+	public Optional<Long> getLong(String key) {
+		return get(key).map(safeParse(Long::parseLong));
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a long.
+	 * If no value in the key slot is found ir the value cannot be converted to a long,
+	 * the default value is used instead.
+	 *
+	 * @param key          the key to which the value is assigned
+	 * @param defaultValue the value which are returned if no value in the key slot is found
+	 *                     or the value in the key slot is not parsable
+	 * @return the value in the key slot as a long or the default value if the key slot is empty
+	 * @see MultiMap#get(String)
+	 */
+	public long getLong(String key, long defaultValue) {
+		return getLong(key).orElse(defaultValue);
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a float.
+	 * If no value in the key slot is found or the value cannot be converted to a float,
+	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 *
+	 * @param key the key to which the value is assigned
+	 * @return the value as a float wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @see MultiMap#get(String)
+	 */
+	public Optional<Float> getFloat(String key) {
+		return get(key).map(safeParse(Float::parseFloat));
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a float.
+	 * If no value in the key slot is found ir the value cannot be converted to a float,
+	 * the default value is used instead.
+	 *
+	 * @param key          the key to which the value is assigned
+	 * @param defaultValue the value which are returned if no value in the key slot is found
+	 *                     or the value in the key slot is not parsable
+	 * @return the value in the key slot as a float or the default value if the key slot is empty
+	 * @see MultiMap#get(String)
+	 */
+	public float getFloat(String key, float defaultValue) {
+		return getFloat(key).orElse(defaultValue);
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a double.
+	 * If no value in the key slot is found or the value cannot be converted to a double,
+	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 *
+	 * @param key the key to which the value is assigned
+	 * @return the value as a double wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @see MultiMap#get(String)
+	 */
+	public Optional<Double> getDouble(String key) {
+		return get(key).map(safeParse(Double::parseDouble));
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a double.
+	 * If no value in the key slot is found ir the value cannot be converted to a double,
+	 * the default value is used instead.
+	 *
+	 * @param key          the key to which the value is assigned
+	 * @param defaultValue the value which are returned if no value in the key slot is found
+	 *                     or the value in the key slot is not parsable
+	 * @return the value in the key slot as a double or the default value if the key slot is empty
+	 * @see MultiMap#get(String)
+	 */
+	public double getDouble(String key, double defaultValue) {
+		return getDouble(key).orElse(defaultValue);
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a character.
+	 * If no value in the key slot is found or the value cannot be converted to a character,
+	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 *
+	 * @param key the key to which the value is assigned
+	 * @return the value as a character wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @see MultiMap#get(String)
+	 */
+	public Optional<Character> getChar(String key) {
+		return get(key).map(value -> value.length() == 1 ? value.charAt(0) : null);
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a character.
+	 * If no value in the key slot is found ir the value cannot be converted to a character,
+	 * the default value is used instead.
+	 *
+	 * @param key          the key to which the value is assigned
+	 * @param defaultValue the value which are returned if no value in the key slot is found
+	 *                     or the value in the key slot is not parsable
+	 * @return the value in the key slot as a character or the default value if the key slot is empty
+	 * @see MultiMap#get(String)
+	 */
+	public char getChar(String key, char defaultValue) {
+		return getChar(key).orElse(defaultValue);
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a boolean.
+	 * If no value in the key slot is found or the value cannot be converted to a boolean,
+	 * an {@link Optional#empty() empty Optional} is returned instead.
+	 *
+	 * @param key the key to which the value is assigned
+	 * @return the value as a boolean wrapped inside a {@link Optional} for better {@code null} type safety
+	 * @see MultiMap#get(String)
+	 */
+	public Optional<Boolean> getBoolean(String key) {
+		return get(key).map(Boolean::parseBoolean);
+	}
+
+	/**
+	 * Returns the current value of the given key in the {@link MultiMap Vert.x headers} as a character.
+	 * If no value in the key slot is found ir the value cannot be converted to a character,
+	 * the default value is used instead.
+	 *
+	 * @param key          the key to which the value is assigned
+	 * @param defaultValue the value which are returned if no value in the key slot is found
+	 *                     or the value in the key slot is not parsable
+	 * @return the value in the key slot as a character or the default value if the key slot is empty
+	 * @see MultiMap#get(String)
+	 */
+	public boolean getBoolean(String key, boolean defaultValue) {
+		return getBoolean(key).orElse(defaultValue);
+	}
+
+	/**
+	 * Returns a list of all stored values in the specified key slot of the wrapped {@link MultiMap Vert.x headers}.
+	 *
+	 * @param key the key to which the values are assigned
+	 * @return the stored values as a list or an empty list if no values are stored
+	 * @see MultiMap#getAll(String)
+	 */
+	public List<String> getAll(String key) {
+		return headers.getAll(key);
+	}
+
+	///
+	/// ADD METHODS
+	///
+
+	/**
+	 * Adds multiple strings to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new strings that should be added to the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#add(String, Iterable)
+	 */
+	public HeaderInformation add(String key, String... values) {
+		return add(key, List.of(values));
+	}
+
+	/**
+	 * Adds multiple characters to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new characters that should be added to the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#add(String, Iterable)
+	 */
+	public HeaderInformation add(String key, Character... values) {
+		return add(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Adds multiple integers to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new integers that should be added to the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#add(String, Iterable)
+	 */
+	public HeaderInformation add(String key, Integer... values) {
+		return add(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Adds multiple longs to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new longs that should be added to the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#add(String, Iterable)
+	 */
+	public HeaderInformation add(String key, Long... values) {
+		return add(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Adds multiple shorts to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new shorts that should be added to the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#add(String, Iterable)
+	 */
+	public HeaderInformation add(String key, Short... values) {
+		return add(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Adds multiple bytes to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new bytes that should be added to the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#add(String, Iterable)
+	 */
+	public HeaderInformation add(String key, Byte... values) {
+		return add(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Adds multiple doubles to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new doubles that should be added to the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#add(String, Iterable)
+	 */
+	public HeaderInformation add(String key, Double... values) {
+		return add(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Adds multiple booleans to the specified key slot of the {@link MultiMap Vert.x headers}.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new booleans that should be added to the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#add(String, Iterable)
+	 */
+	public HeaderInformation add(String key, Boolean... values) {
+		return add(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Intermediate step to add a list of strings to the wrapped {@link MultiMap Vert.x headers}.
+	 */
+	private HeaderInformation add(String key, List<String> list) {
+		headers.add(key, list);
+		return this;
+	}
+
+	///
+	/// SET METHODS
+	///
+
+	/**
+	 * Sets multiple strings in the specified key slot of the {@link MultiMap Vert.x headers}
+	 * and replaces potentially existing values.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new strings that should be replaced in the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, String... values) {
+		return set(key, List.of(values));
+	}
+
+	/**
+	 * Sets multiple characters in the specified key slot of the {@link MultiMap Vert.x headers}
+	 * and replaces potentially existing values.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new characters that should be replaced in the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Character... values) {
+		return set(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Sets multiple integers in the specified key slot of the {@link MultiMap Vert.x headers}
+	 * and replaces potentially existing values.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new integers that should be replaced in the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Integer... values) {
+		return set(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Sets multiple longs in the specified key slot of the {@link MultiMap Vert.x headers}
+	 * and replaces potentially existing values.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new longs that should be replaced in the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Long... values) {
+		return set(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Sets multiple shorts in the specified key slot of the {@link MultiMap Vert.x headers}
+	 * and replaces potentially existing values.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new shorts that should be replaced in the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Short... values) {
+		return set(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Sets multiple bytes in the specified key slot of the {@link MultiMap Vert.x headers}
+	 * and replaces potentially existing values.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new bytes that should be replaced in the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Byte... values) {
+		return set(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Sets multiple doubles in the specified key slot of the {@link MultiMap Vert.x headers}
+	 * and replaces potentially existing values.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new doubles that should be replaced in the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Double... values) {
+		return set(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Sets multiple floats in the specified key slot of the {@link MultiMap Vert.x headers}
+	 * and replaces potentially existing values.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new floats that should be replaced in the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Float... values) {
+		return set(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Sets multiple booleans in the specified key slot of the {@link MultiMap Vert.x headers}
+	 * and replaces potentially existing values.
+	 *
+	 * @param key    the key to which the value is assigned
+	 * @param values the new booleans that should be replaced in the key slot
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#set(String, Iterable)
+	 */
+	public HeaderInformation set(String key, Boolean... values) {
+		return set(key, Stream.of(values).map(String::valueOf).toList());
+	}
+
+	/**
+	 * Intermediate step to set a list of strings in the wrapped {@link MultiMap Vert.x headers}.
+	 */
+	private HeaderInformation set(String key, List<String> values) {
+		headers.set(key, values);
+		return this;
+	}
+
+	///
+	/// OTHER METHODS FROM MULTIMAP
+	///
+
+	/**
+	 * Replaces all key slots of the wrapped {@link MultiMap Vert.x headers} with the specified ones.
+	 * All other existing key slots are cleared.
+	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 *
+	 * @param headers the {@link MultiMap Vert.x headers} that contains the new key slots and associated values
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#setAll(MultiMap)
+	 */
+	public HeaderInformation setAll(MultiMap headers) {
+		this.headers.setAll(headers);
+		return this;
+	}
+
+	/**
+	 * Replaces all key slots of the wrapped {@link MultiMap Vert.x headers} with the specified ones.
+	 * All other existing key slots are cleared.
+	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 *
+	 * @param headers a {@link Map} that contains the new key slots and associated values
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#setAll(Map)
+	 */
+	public HeaderInformation setAll(Map<String, String> headers) {
+		this.headers.setAll(headers);
+		return this;
+	}
+
+	/**
+	 * Replaces all key slots of the wrapped {@link MultiMap Vert.x headers}
+	 * with the wrapped {@link MultiMap Vert.x headers} of the specified instance.
+	 * All other existing key slots are cleared.
+	 * It is effectively an entire replacement of the entire {@link MultiMap} instance.
+	 *
+	 * @param information the other {@link HeaderInformation} instance that contains the new key slots
+	 *                    and associated values
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see HeaderInformation#setAll(MultiMap)
+	 */
+	public HeaderInformation setAll(HeaderInformation information) {
+		return setAll(information.headers);
+	}
+
+	/**
+	 * Adds all key slots and values of the specified {@link MultiMap Vert.x headers}
+	 * to the wrapped {@link MultiMap Vert.x headers}.
+	 *
+	 * @param headers the {@link MultiMap Vert.x headers} that contain the new key slots and values
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#addAll(MultiMap)
+	 */
+	public HeaderInformation addAll(MultiMap headers) {
+		this.headers.addAll(headers);
+		return this;
+	}
+
+	/**
+	 * Adds all key slots and values of the specified {@link Map} to the wrapped {@link MultiMap Vert.x headers}.
+	 *
+	 * @param headers the {@link Map} that contain the new key slots and values
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#addAll(Map)
+	 */
+	public HeaderInformation addAll(Map<String, String> headers) {
+		this.headers.addAll(headers);
+		return this;
+	}
+
+	/**
+	 * Adds all key slots and values of the specified {@link HeaderInformation} instance
+	 * to the wrapped {@link MultiMap Vert.x headers}.
+	 *
+	 * @param information the other {@link HeaderInformation} instance that contains the new key slots
+	 *                    and associated values
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#addAll(MultiMap)
+	 */
+	public HeaderInformation addAll(HeaderInformation information) {
+		return addAll(information.headers);
+	}
+
+	/**
+	 * Removes all values from the specified key slot on the wrapped {@link MultiMap Vert.x headers}.
+	 *
+	 * @param name the key to which the values are assigned
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#remove(String)
+	 */
+	public HeaderInformation remove(String name) {
+		headers.remove(name);
+		return this;
+	}
+
+	/**
+	 * Clears all key slots and values from the wrapped {@link MultiMap Vert.x headers}.
+	 *
+	 * @return a reference to {@code this}, so the API can be used fluently
+	 * @see MultiMap#clear()
+	 */
+	public HeaderInformation clear() {
+		headers.clear();
+		return this;
+	}
+
+	/**
+	 * Returns the number of currently used key slots in the wrapped {@link MultiMap Vert.x headers}.
+	 *
+	 * @return the number of used key slots in the {@link MultiMap Vert.x headers}
+	 * @see MultiMap#size()
+	 */
+	public int size() {
+		return headers.size();
+	}
+
+	/**
+	 * Returns an immutable set of all keys currently used in the wrapped {@link MultiMap Vert.x headers}.
+	 *
+	 * @return an immutable set of all keys in the wrapped {@link MultiMap Vert.x headers}
+	 * @see MultiMap#names()
+	 */
+	public Set<String> names() {
+		return headers.names();
+	}
+
+	/**
+	 * Returns {@code true}, if the wrapped {@link MultiMap Vert.x headers} has no entries.
+	 *
+	 * @return returns {@code true} if the wrapped {@link MultiMap Vert.x headers} has no entries
+	 * @see MultiMap#isEmpty()
+	 */
+	public boolean isEmpty() {
+		return headers.isEmpty();
+	}
+
+	/**
+	 * The wrapped {@link MultiMap Vert.x headers} instance that is manipulated
+	 * through the exposed {@link HeaderInformation} APIs.
+	 */
+	private final MultiMap headers;
+
+	/**
+	 * Wraps the specified function into a {@link NumberFormatException} try-catch block
+	 * to prevent exception breakout in the parsing steps above.
+	 * If the value cannot be parsed, {@code null} is returned instead.
+	 *
+	 * @param func the function that can throw a {@link NumberFormatException} during parsing
+	 * @param <T>  the type of the input to the function
+	 * @param <R>  the type of the result to the function
+	 * @return another function which wraps the given function into a {@link NumberFormatException} try-catch block
+	 */
+	private static <T, R> Function<T, R> safeParse(Function<T, R> func) {
+		return value -> {
+			try {
+				return func.apply(value);
+			} catch (NumberFormatException e) {
+				return null;
+			}
+		};
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/JsonMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/JsonMessage.java
@@ -51,12 +51,12 @@ public interface JsonMessage {
 	}
 
 	/**
-	 * This method decodes a {@link JsonMessage} from the event bus.<br>
-	 * It returns a future, which resolves, if the message was successfully decoded,
-	 * and rejects, if something went wrong during decoding.
+	 * This method decodes a {@link JsonMessage}.<br>
+	 * It returns a future which resolves if the message was successfully decoded,
+	 * and rejects if something went wrong during decoding.
 	 *
-	 * @param clazz   Class of the message-object
-	 * @param msgBody {@link Message#body() msg-body} of the sent message
+	 * @param clazz   Class of the message object
+	 * @param msgBody {@link Message#body() msg-body} of the message
 	 * @param <T>     Generic type for the {@link Future}
 	 * @return a future which resolves when the decoding was successful
 	 */
@@ -83,12 +83,12 @@ public interface JsonMessage {
 	}
 
 	/**
-	 * This method decodes a {@link JsonMessage} from the event bus.<br>
-	 * It returns a future, which resolves, if the message was successfully decoded,
-	 * and rejects, if something went wrong during decoding.
+	 * This method decodes a {@link JsonMessage}.<br>
+	 * It returns a future which resolves if the message was successfully decoded,
+	 * and rejects if something went wrong during decoding.
 	 *
-	 * @param clazz Class of the message-object
-	 * @param msg   sent message
+	 * @param clazz Class of the message object
+	 * @param msg   message
 	 * @param <T>   Generic type for the {@link Future}
 	 * @return a future which resolves when the decoding was successful
 	 */

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/JsonMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/JsonMessage.java
@@ -23,14 +23,14 @@ public interface JsonMessage {
 	Logger logger = LoggerFactory.getLogger(JsonMessage.class);
 
 	/**
-	 * This method decodes a {@link JsonMessage} from the event bus.<br>
-	 * Returns whether decoding was successful or not.
+	 * This method decodes a {@link JsonMessage}.<br>
+	 * Returns {@code true}, if the conversion was successful.
 	 *
-	 * @param clazz   Class of the message-object
-	 * @param msgBody {@link Message#body() msg-body} of the sent message
+	 * @param clazz   Class of the message object
+	 * @param msgBody {@link Message#body() msg-body} of the message
 	 * @param handler handler for the message
 	 * @param <T>     Generic type for the {@link Handler}
-	 * @return whether decoding was successful
+	 * @return {@code true}, if the conversion was successful
 	 */
 	static <T extends JsonMessage> boolean on(Class<T> clazz, Object msgBody, Handler<T> handler) {
 		if (msgBody instanceof JsonObject jsonObject && jsonObject.containsKey("className")) {
@@ -69,14 +69,14 @@ public interface JsonMessage {
 	}
 
 	/**
-	 * This method decodes a {@link JsonMessage} from the event bus.<br>
-	 * Returns whether decoding was successful or not.
+	 * This method decodes a {@link JsonMessage}.<br>
+	 * Returns {@code true}, if the conversion was successful.
 	 *
-	 * @param clazz   Class of the message-object
-	 * @param msg     sent message
+	 * @param clazz   Class of the message object
+	 * @param msg     message
 	 * @param handler handler for the message
 	 * @param <T>     type of the {@link Message}
-	 * @return whether decoding was successful
+	 * @return {@code true}, if the conversion was successful
 	 */
 	static <T extends JsonMessage> boolean on(Class<T> clazz, Message<?> msg, Handler<T> handler) {
 		return on(clazz, msg.body(), handler);

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/JsonMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/JsonMessage.java
@@ -1,6 +1,7 @@
 package de.wuespace.telestion.api.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
@@ -20,6 +21,7 @@ import org.slf4j.LoggerFactory;
 public interface JsonMessage {
 	JsonCodec JSON_CODEC = new JacksonCodec();
 	Logger logger = LoggerFactory.getLogger(JsonMessage.class);
+
 	/**
 	 * This method decodes a {@link JsonMessage} from the event bus.<br>
 	 * Returns whether decoding was successful or not.
@@ -50,6 +52,24 @@ public interface JsonMessage {
 
 	/**
 	 * This method decodes a {@link JsonMessage} from the event bus.<br>
+	 * It returns a future, which resolves, if the message was successfully decoded,
+	 * and rejects, if something went wrong during decoding.
+	 *
+	 * @param clazz   Class of the message-object
+	 * @param msgBody {@link Message#body() msg-body} of the sent message
+	 * @param <T>     Generic type for the {@link Future}
+	 * @return a future which resolves when the decoding was successful
+	 */
+	static <T extends JsonMessage> Future<T> on(Class<T> clazz, Object msgBody) {
+		return Future.future(promise -> {
+			if (!on(clazz, msgBody, promise::complete)) {
+				promise.fail("Cannot decode message.");
+			}
+		});
+	}
+
+	/**
+	 * This method decodes a {@link JsonMessage} from the event bus.<br>
 	 * Returns whether decoding was successful or not.
 	 *
 	 * @param clazz   Class of the message-object
@@ -60,6 +80,20 @@ public interface JsonMessage {
 	 */
 	static <T extends JsonMessage> boolean on(Class<T> clazz, Message<?> msg, Handler<T> handler) {
 		return on(clazz, msg.body(), handler);
+	}
+
+	/**
+	 * This method decodes a {@link JsonMessage} from the event bus.<br>
+	 * It returns a future, which resolves, if the message was successfully decoded,
+	 * and rejects, if something went wrong during decoding.
+	 *
+	 * @param clazz Class of the message-object
+	 * @param msg   sent message
+	 * @param <T>   Generic type for the {@link Future}
+	 * @return a future which resolves when the decoding was successful
+	 */
+	static <T extends JsonMessage> Future<T> on(Class<T> clazz, Message<?> msg) {
+		return on(clazz, msg.body());
 	}
 
 	/**

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/MultiMapUtils.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/MultiMapUtils.java
@@ -1,0 +1,72 @@
+package de.wuespace.telestion.api.message;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Utilities for the {@link MultiMap Vert.x multimap}.
+ *
+ * @author Ludwig Richter (fussel178)
+ */
+public class MultiMapUtils {
+
+	/**
+	 * Merges an array of multi-maps into one multimap
+	 * with the {@link MultiMap#addAll(MultiMap) addAll} function.
+	 *
+	 * @param maps multiple multi-maps that should be merged into one
+	 * @return a new multimap with the merged content of the other multi-maps
+	 */
+	public static MultiMap merge(MultiMap... maps) {
+		return merge(Arrays.stream(maps));
+	}
+
+	/**
+	 * Merges a list of multi-maps into one multimap
+	 * with the {@link MultiMap#addAll(MultiMap) addAll} function.
+	 *
+	 * @param list multiple multi-maps that should be merged into one
+	 * @return a new multimap with the merged content of the other multi-maps
+	 */
+	public static MultiMap merge(List<MultiMap> list) {
+		return merge(list.stream());
+	}
+
+	/**
+	 * Merges a stream of multi-maps into one multimap
+	 * with the {@link MultiMap#addAll(MultiMap) addAll} function.
+	 *
+	 * @param stream a stream that contains multi-maps that should be merged into one
+	 * @return a new multimap with the merged content of the other multi-maps
+	 */
+	public static MultiMap merge(Stream<MultiMap> stream) {
+		var finalMap = MultiMap.caseInsensitiveMultiMap();
+		stream.forEachOrdered(finalMap::addAll);
+		return finalMap;
+	}
+
+	/**
+	 * Extracts the {@link MultiMap Vert.x headers} from the received {@link Message}.
+	 *
+	 * @param message the {@link Message} that contains the {@link MultiMap Vert.x headers}
+	 * @return the extracted {@link MultiMap Vert.x headers}
+	 */
+	public static MultiMap from(Message<?> message) {
+		return message.headers();
+	}
+
+	/**
+	 * Extracts the {@link MultiMap Vert.x headers} from the specified {@link DeliveryOptions}.
+	 *
+	 * @param options the {@link DeliveryOptions} that contain the {@link MultiMap Vert.x headers}
+	 * @return the extracted {@link MultiMap Vert.x headers}
+	 */
+	public static MultiMap from(DeliveryOptions options) {
+		return options.getHeaders();
+	}
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/MultiMapUtils.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/MultiMapUtils.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 /**
  * Utilities for the {@link MultiMap Vert.x multimap}.
  *
- * @author Ludwig Richter (fussel178)
+ * @author Ludwig Richter (@fussel178)
  */
 public class MultiMapUtils {
 

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/MultiMapUtils.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/message/MultiMapUtils.java
@@ -16,33 +16,33 @@ import java.util.stream.Stream;
 public class MultiMapUtils {
 
 	/**
-	 * Merges an array of multi-maps into one multimap
+	 * Merges an array of multi-maps into one multi-map
 	 * with the {@link MultiMap#addAll(MultiMap) addAll} function.
 	 *
-	 * @param maps multiple multi-maps that should be merged into one
-	 * @return a new multimap with the merged content of the other multi-maps
+	 * @param maps multi-maps that you want to merge
+	 * @return a new multi-map with the merged content of the other multi-maps
 	 */
 	public static MultiMap merge(MultiMap... maps) {
 		return merge(Arrays.stream(maps));
 	}
 
 	/**
-	 * Merges a list of multi-maps into one multimap
+	 * Merges a list of multi-maps into one multi-map
 	 * with the {@link MultiMap#addAll(MultiMap) addAll} function.
 	 *
-	 * @param list multiple multi-maps that should be merged into one
-	 * @return a new multimap with the merged content of the other multi-maps
+	 * @param list multi-maps that you want to merge
+	 * @return a new multi-map with the merged content of the other multi-maps
 	 */
 	public static MultiMap merge(List<MultiMap> list) {
 		return merge(list.stream());
 	}
 
 	/**
-	 * Merges a stream of multi-maps into one multimap
+	 * Merges a stream of multi-maps into one multi-map
 	 * with the {@link MultiMap#addAll(MultiMap) addAll} function.
 	 *
-	 * @param stream a stream that contains multi-maps that should be merged into one
-	 * @return a new multimap with the merged content of the other multi-maps
+	 * @param stream a stream that contains the multi-maps that you want to merge
+	 * @return a new multi-map with the merged content of the other multi-maps
 	 */
 	public static MultiMap merge(Stream<MultiMap> stream) {
 		var finalMap = MultiMap.caseInsensitiveMultiMap();
@@ -51,7 +51,7 @@ public class MultiMapUtils {
 	}
 
 	/**
-	 * Extracts the {@link MultiMap Vert.x headers} from the received {@link Message}.
+	 * Extracts the {@link MultiMap Vert.x headers} from the {@link Message}.
 	 *
 	 * @param message the {@link Message} that contains the {@link MultiMap Vert.x headers}
 	 * @return the extracted {@link MultiMap Vert.x headers}
@@ -61,7 +61,7 @@ public class MultiMapUtils {
 	}
 
 	/**
-	 * Extracts the {@link MultiMap Vert.x headers} from the specified {@link DeliveryOptions}.
+	 * Extracts the {@link MultiMap Vert.x headers} from the {@link DeliveryOptions}.
 	 *
 	 * @param options the {@link DeliveryOptions} that contain the {@link MultiMap Vert.x headers}
 	 * @return the extracted {@link MultiMap Vert.x headers}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
@@ -7,8 +7,7 @@ import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 
 /**
- * A wrapper for a decoded message from the {@link Message Vert.x message} to the {@link JsonMessage} type
- * and basis {@link Message Vert.x message}
+ * A wrapper for a {@link Message Vert.x message} and its body as {@link JsonMessage}.
  *
  * @param message the {@link Message Vert.x message}
  * @param body    the decoded body of the {@link Message Vert.x message}
@@ -24,14 +23,15 @@ public record DecodedMessage<V extends JsonMessage, T extends JsonObject>(
 ) implements JsonMessage {
 
 	/**
-	 * Composes the given future, which eventually returns the received message, with the returned future
-	 * to map from the {@link Message Vert.x message} to the {@link JsonMessage} type.
+	 * Returns a future which succeeds with the {@code messageFuture}'s body as {@link JsonMessage}.
+	 * Fails if the {@code messageFuture}'s body cannot be mapped to the {@link JsonMessage} type
+	 * or the {@code messageFuture} fails.
 	 *
 	 * @param clazz         the class type of the {@link JsonMessage} to map to
 	 * @param messageFuture the future that returns the received message
 	 * @param <V>           the type of {@link JsonMessage} to map to
 	 * @param <T>           the type of the body of the {@link Message Vert.x message}
-	 * @return a new future composed from the passed future that maps to the {@link JsonMessage} type
+	 * @return a future which succeeds with the {@code messageFuture}'s body as {@link JsonMessage}
 	 * @see JsonMessage#on(Class, Message)
 	 */
 	public static <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> compose(
@@ -41,14 +41,14 @@ public record DecodedMessage<V extends JsonMessage, T extends JsonObject>(
 	}
 
 	/**
-	 * Decodes the {@link Message Vert.x message} to the {@link JsonMessage} type and returns a {@link Future}
-	 * which eventually returns a {@link DecodedMessage} with the message's contents.
+	 * Return a future which succeeds with the {@link Message Vert.x message}'s body as {@link JsonMessage}.
+	 * Fails if the {@link Message Vert.x message}'s body cannot be mapped to the {@link JsonMessage} type.
 	 *
 	 * @param clazz   the class type of the {@link JsonMessage} to map to
 	 * @param message the {@link Message Vert.x message}
 	 * @param <V>     the type of {@link JsonMessage} to map to
 	 * @param <T>     the type of the body of the {@link Message Vert.x message}
-	 * @return a new future which eventually returns a {@link DecodedMessage} with the message's contents
+	 * @return a new future which returns a {@link DecodedMessage} with the message's contents
 	 * @see JsonMessage#on(Class, Message)
 	 */
 	public static <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> on(

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
@@ -10,10 +10,10 @@ import io.vertx.core.json.JsonObject;
  * A wrapper for a decoded message from the {@link Message Vert.x message} to the {@link JsonMessage} type
  * and basis {@link Message Vert.x message}
  *
- * @param message the basic {@link Message Vert.x message}
- * @param body    the decoded body of the {@link Message Vert.x message} to the {@link JsonMessage} type
- * @param <V>     the type of the {@link JsonMessage} to map to
- * @param <T>     the type of body of the {@link Message Vert.x message}
+ * @param message the {@link Message Vert.x message}
+ * @param body    the decoded body of the {@link Message Vert.x message}
+ * @param <V>     the type of {@link JsonMessage} to map to
+ * @param <T>     the type of the body of the {@link Message Vert.x message}
  * @see JsonMessage#on(Class, Message)
  *
  * @author Ludwig Richter (@fussel178)
@@ -28,11 +28,10 @@ public record DecodedMessage<V extends JsonMessage, T extends JsonObject>(
 	 * to map from the {@link Message Vert.x message} to the {@link JsonMessage} type.
 	 *
 	 * @param clazz         the class type of the {@link JsonMessage} to map to
-	 * @param messageFuture the given future which eventually returns the received message
-	 * @param <V>           the type of the {@link JsonMessage} to map to
-	 * @param <T>           the type of body of the {@link Message Vert.x message}
-	 * @return a new future composed with the given future that maps from the {@link Message Vert.x message}
-	 * to the {@link JsonMessage} type
+	 * @param messageFuture the future that returns the received message
+	 * @param <V>           the type of {@link JsonMessage} to map to
+	 * @param <T>           the type of the body of the {@link Message Vert.x message}
+	 * @return a new future composed from the passed future that maps to the {@link JsonMessage} type
 	 * @see JsonMessage#on(Class, Message)
 	 */
 	public static <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> compose(
@@ -42,14 +41,14 @@ public record DecodedMessage<V extends JsonMessage, T extends JsonObject>(
 	}
 
 	/**
-	 * Decodes the given {@link Message Vert.x message} to the {@link JsonMessage} type and returns a {@link Future}
-	 * which eventually returns a {@link DecodedMessage} with the mapped contents.
+	 * Decodes the {@link Message Vert.x message} to the {@link JsonMessage} type and returns a {@link Future}
+	 * which eventually returns a {@link DecodedMessage} with the message's contents.
 	 *
 	 * @param clazz   the class type of the {@link JsonMessage} to map to
-	 * @param message the received {@link Message Vert.x message}
-	 * @param <V>     the type of the {@link JsonMessage} to map to
-	 * @param <T>     the type of body of the {@link Message Vert.x message}
-	 * @return a new future which eventually returns a {@link DecodedMessage} with the mapped contents
+	 * @param message the {@link Message Vert.x message}
+	 * @param <V>     the type of {@link JsonMessage} to map to
+	 * @param <T>     the type of the body of the {@link Message Vert.x message}
+	 * @return a new future which eventually returns a {@link DecodedMessage} with the message's contents
 	 * @see JsonMessage#on(Class, Message)
 	 */
 	public static <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> on(

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
@@ -2,11 +2,59 @@ package de.wuespace.telestion.api.verticle.trait;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import de.wuespace.telestion.api.message.JsonMessage;
+import io.vertx.core.Future;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 
+/**
+ * A wrapper for a decoded message from the {@link Message Vert.x message} to the {@link JsonMessage} type
+ * and basis {@link Message Vert.x message}
+ *
+ * @param message the basic {@link Message Vert.x message}
+ * @param body    the decoded body of the {@link Message Vert.x message} to the {@link JsonMessage} type
+ * @param <V>     the type of the {@link JsonMessage} to map to
+ * @param <T>     the type of body of the {@link Message Vert.x message}
+ * @see JsonMessage#on(Class, Message)
+ *
+ * @author Ludwig Richter (@fussel178)
+ */
 public record DecodedMessage<V extends JsonMessage, T extends JsonObject>(
 		@JsonProperty V body,
 		@JsonProperty Message<T> message
 ) implements JsonMessage {
+
+	/**
+	 * Composes the given future, which eventually returns the received message, with the returned future
+	 * to map from the {@link Message Vert.x message} to the {@link JsonMessage} type.
+	 *
+	 * @param clazz         the class type of the {@link JsonMessage} to map to
+	 * @param messageFuture the given future which eventually returns the received message
+	 * @param <V>           the type of the {@link JsonMessage} to map to
+	 * @param <T>           the type of body of the {@link Message Vert.x message}
+	 * @return a new future composed with the given future that maps from the {@link Message Vert.x message}
+	 * to the {@link JsonMessage} type
+	 * @see JsonMessage#on(Class, Message)
+	 */
+	public static <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> compose(
+			Class<V> clazz,
+			Future<Message<T>> messageFuture) {
+		return messageFuture.compose(message -> on(clazz, message));
+	}
+
+	/**
+	 * Decodes the given {@link Message Vert.x message} to the {@link JsonMessage} type and returns a {@link Future}
+	 * which eventually returns a {@link DecodedMessage} with the mapped contents.
+	 *
+	 * @param clazz   the class type of the {@link JsonMessage} to map to
+	 * @param message the received {@link Message Vert.x message}
+	 * @param <V>     the type of the {@link JsonMessage} to map to
+	 * @param <T>     the type of body of the {@link Message Vert.x message}
+	 * @return a new future which eventually returns a {@link DecodedMessage} with the mapped contents
+	 * @see JsonMessage#on(Class, Message)
+	 */
+	public static <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> on(
+			Class<V> clazz,
+			Message<T> message) {
+		return JsonMessage.on(clazz, message).map(decoded -> new DecodedMessage<>(decoded, message));
+	}
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/DecodedMessage.java
@@ -23,7 +23,7 @@ public record DecodedMessage<V extends JsonMessage, T extends JsonObject>(
 ) implements JsonMessage {
 
 	/**
-	 * Returns a future which succeeds with the {@code messageFuture}'s body as {@link JsonMessage}.
+	 * Returns a {@link Future} which succeeds with the {@code messageFuture}'s body as {@link JsonMessage}.
 	 * Fails if the {@code messageFuture}'s body cannot be mapped to the {@link JsonMessage} type
 	 * or the {@code messageFuture} fails.
 	 *
@@ -31,7 +31,7 @@ public record DecodedMessage<V extends JsonMessage, T extends JsonObject>(
 	 * @param messageFuture the future that returns the received message
 	 * @param <V>           the type of {@link JsonMessage} to map to
 	 * @param <T>           the type of the body of the {@link Message Vert.x message}
-	 * @return a future which succeeds with the {@code messageFuture}'s body as {@link JsonMessage}
+	 * @return a new {@link Future} which succeeds with the {@code messageFuture}'s body as {@link JsonMessage}
 	 * @see JsonMessage#on(Class, Message)
 	 */
 	public static <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> compose(
@@ -41,14 +41,14 @@ public record DecodedMessage<V extends JsonMessage, T extends JsonObject>(
 	}
 
 	/**
-	 * Return a future which succeeds with the {@link Message Vert.x message}'s body as {@link JsonMessage}.
+	 * Return a {@link Future} which succeeds with the {@link Message Vert.x message}'s body as {@link JsonMessage}.
 	 * Fails if the {@link Message Vert.x message}'s body cannot be mapped to the {@link JsonMessage} type.
 	 *
 	 * @param clazz   the class type of the {@link JsonMessage} to map to
 	 * @param message the {@link Message Vert.x message}
 	 * @param <V>     the type of {@link JsonMessage} to map to
 	 * @param <T>     the type of the body of the {@link Message Vert.x message}
-	 * @return a new future which returns a {@link DecodedMessage} with the message's contents
+	 * @return a new {@link Future} which returns a {@link DecodedMessage} with the message's contents
 	 * @see JsonMessage#on(Class, Message)
 	 */
 	public static <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> on(

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/WithEventBus.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/trait/WithEventBus.java
@@ -1,8 +1,11 @@
 package de.wuespace.telestion.api.verticle.trait;
 
+import de.wuespace.telestion.api.message.HeaderInformation;
 import de.wuespace.telestion.api.message.JsonMessage;
+import de.wuespace.telestion.api.message.MultiMapUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
 import io.vertx.core.Verticle;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.Message;
@@ -10,34 +13,86 @@ import io.vertx.core.json.JsonObject;
 
 /**
  * Allows {@link Verticle} instances to get simplified access to the Vert.x event bus.
- * All methods allow usage with {@link JsonMessage} messages, too.
+ * These traits support automatic conversion of different message types like {@link JsonMessage}
+ * and automatic attachment of {@link MultiMap} or {@link HeaderInformation} to sent messages on the event bus.
  *
  * <h2>Usage</h2>
  * <pre>
  * {@code
  * public class MyVerticle extends TelestionVerticle implements WithEventBus {
  *     @Override
- *     public void startVerticle() {
- *         register("channel-1", this::handle, SimpleMessage.class);
+ *     public void onStart() {
+ *         register("channel-1", this::handle, Position.class);
  *     }
  *
- *     private void handle(SimpleMessage body) {
- *         logger.info("Received Telecommand: {}", body.tcClass());
+ *     private void handle(Position position) {
+ *         logger.info("Current position: {}, {}", position.x, position.y);
  *     }
  * }
  * }
  * </pre>
  *
- * @author Pablo Klaschka, Ludwig Richter
+ * @author Pablo Klaschka (@pklaschka), Ludwig Richter (@fussel178)
  */
 public interface WithEventBus extends Verticle {
-	/* PUBLISH */
+
+	///
+	/// PUBLISH SECTION
+	///
+
+	/**
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object)
+	 */
+	default void publish(String address, Object message) {
+		getVertx().eventBus().publish(address, message);
+	}
 
 	/**
 	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object, DeliveryOptions)
 	 */
 	default void publish(String address, Object message, DeliveryOptions options) {
 		getVertx().eventBus().publish(address, message, options);
+	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object, DeliveryOptions)
+	 */
+	default void publish(String address, Object message, DeliveryOptions options, MultiMap... headers) {
+		options.setHeaders(MultiMapUtils.merge(headers));
+		publish(address, message, options);
+	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object, DeliveryOptions)
+	 */
+	default void publish(String address, Object message, DeliveryOptions options, HeaderInformation... headers) {
+		HeaderInformation.merge(headers).attach(options);
+		publish(address, message, options);
+	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object)
+	 */
+	default void publish(String address, Object message, MultiMap... headers) {
+		publish(address, message, new DeliveryOptions(), headers);
+	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object)
+	 */
+	default void publish(String address, Object message, HeaderInformation... headers) {
+		publish(address, message, new DeliveryOptions(), headers);
+	}
+
+	/**
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object)
+	 */
+	default void publish(String address, JsonMessage message) {
+		publish(address, message.json());
 	}
 
 	/**
@@ -48,26 +103,94 @@ public interface WithEventBus extends Verticle {
 	}
 
 	/**
-	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object)
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object, DeliveryOptions)
 	 */
-	default void publish(String address, Object message) {
-		getVertx().eventBus().publish(address, message);
+	default void publish(String address, JsonMessage message, DeliveryOptions options, MultiMap... headers) {
+		publish(address, message.json(), options, headers);
 	}
 
 	/**
-	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object)
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object, DeliveryOptions)
 	 */
-	default void publish(String address, JsonMessage message) {
-		publish(address, message.json());
+	default void publish(String address, JsonMessage message, DeliveryOptions options, HeaderInformation... headers) {
+		publish(address, message.json(), options, headers);
 	}
 
-	/* SEND */
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object)
+	 */
+	default void publish(String address, JsonMessage message, MultiMap... headers) {
+		publish(address, message.json(), headers);
+	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#publish(String, Object)
+	 */
+	default void publish(String address, JsonMessage message, HeaderInformation... headers) {
+		publish(address, message.json(), headers);
+	}
+
+	///
+	/// SEND SECTION
+	///
+
+	/**
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object)
+	 */
+	default void send(String address, Object message) {
+		getVertx().eventBus().send(address, message);
+	}
 
 	/**
 	 * @see io.vertx.core.eventbus.EventBus#send(String, Object, DeliveryOptions)
 	 */
 	default void send(String address, Object message, DeliveryOptions options) {
 		getVertx().eventBus().send(address, message, options);
+	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object, DeliveryOptions)
+	 */
+	default void send(String address, Object message, DeliveryOptions options, MultiMap... headers) {
+		options.setHeaders(MultiMapUtils.merge(headers));
+		send(address, message, options);
+	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object, DeliveryOptions)
+	 */
+	default void send(String address, Object message, DeliveryOptions options, HeaderInformation... headers) {
+		HeaderInformation.merge(headers).attach(options);
+		send(address, message, options);
+	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object)
+	 */
+	default void send(String address, Object message, MultiMap... headers) {
+		send(address, message, new DeliveryOptions(), headers);
+	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object)
+	 */
+	default void send(String address, Object message, HeaderInformation... headers) {
+		send(address, message, new DeliveryOptions(), headers);
+	}
+
+	/**
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object)
+	 */
+	default void send(String address, JsonMessage message) {
+		send(address, message.json());
 	}
 
 	/**
@@ -78,27 +201,40 @@ public interface WithEventBus extends Verticle {
 	}
 
 	/**
-	 * @see io.vertx.core.eventbus.EventBus#send(String, Object)
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object, DeliveryOptions)
 	 */
-	default void send(String address, Object message) {
-		getVertx().eventBus().send(address, message);
+	default void send(String address, JsonMessage message, DeliveryOptions options, MultiMap... headers) {
+		send(address, message.json(), options, headers);
 	}
 
 	/**
-	 * @see io.vertx.core.eventbus.EventBus#send(String, Object)
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object, DeliveryOptions)
 	 */
-	default void send(String address, JsonMessage message) {
-		send(address, message.json());
+	default void send(String address, JsonMessage message, DeliveryOptions options, HeaderInformation... headers) {
+		send(address, message.json(), options, headers);
 	}
-
-	/* REQUEST */
 
 	/**
-	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object)
 	 */
-	default <T> Future<Message<T>> request(String address, Object request, DeliveryOptions options) {
-		return getVertx().eventBus().request(address, request, options);
+	default void send(String address, JsonMessage message, MultiMap... headers) {
+		send(address, message.json(), headers);
 	}
+
+	/**
+	 * @param headers the headers that should be sent with the message
+	 * @see io.vertx.core.eventbus.EventBus#send(String, Object)
+	 */
+	default void send(String address, JsonMessage message, HeaderInformation... headers) {
+		send(address, message.json(), headers);
+	}
+
+	///
+	/// REQUEST SECTION
+	///
 
 	/**
 	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
@@ -108,14 +244,106 @@ public interface WithEventBus extends Verticle {
 	}
 
 	/**
-	 * @param responseType the type of the response to map to
 	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
 	 */
-	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
-			String address, Object request, DeliveryOptions options, Class<V> responseType
-	) {
-		return this.<T>request(address, request, options)
-				.map(raw -> new DecodedMessage<>(raw.body().mapTo(responseType), raw));
+	default <T> Future<Message<T>> request(String address, Object request, DeliveryOptions options) {
+		return getVertx().eventBus().request(address, request, options);
+	}
+
+	/**
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <T> Future<Message<T>> request(
+			String address,
+			Object request,
+			DeliveryOptions options,
+			MultiMap... requestHeaders) {
+		options.setHeaders(MultiMapUtils.merge(requestHeaders));
+		return request(address, request, options);
+	}
+
+	/**
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <T> Future<Message<T>> request(
+			String address,
+			Object request,
+			DeliveryOptions options,
+			HeaderInformation... requestHeaders) {
+		HeaderInformation.merge(requestHeaders).attach(options);
+		return request(address, request, options);
+	}
+
+	/**
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
+	 */
+	default <T> Future<Message<T>> request(String address, Object request, MultiMap... requestHeaders) {
+		return request(address, request, new DeliveryOptions(), requestHeaders);
+	}
+
+	/**
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
+	 */
+	default <T> Future<Message<T>> request(String address, Object request, HeaderInformation... requestHeaders) {
+		return request(address, request, new DeliveryOptions(), requestHeaders);
+	}
+
+	/**
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
+	 */
+	default <T> Future<Message<T>> request(String address, JsonMessage message) {
+		return request(address, message.json());
+	}
+
+	/**
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <T> Future<Message<T>> request(String address, JsonMessage message, DeliveryOptions options) {
+		return request(address, message.json(), options);
+	}
+
+	/**
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <T> Future<Message<T>> request(
+			String address,
+			JsonMessage message,
+			DeliveryOptions options,
+			MultiMap... requestHeaders) {
+		return request(address, message.json(), options, requestHeaders);
+	}
+
+	/**
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <T> Future<Message<T>> request(
+			String address,
+			JsonMessage message,
+			DeliveryOptions options,
+			HeaderInformation... requestHeaders) {
+		return request(address, message.json(), options, requestHeaders);
+	}
+
+	/**
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
+	 */
+	default <T> Future<Message<T>> request(String address, JsonMessage message, MultiMap... requestHeaders) {
+		return request(address, message.json(), requestHeaders);
+	}
+
+	/**
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
+	 */
+	default <T> Future<Message<T>> request(String address, JsonMessage message, HeaderInformation... requestHeaders) {
+		return request(address, message.json(), requestHeaders);
 	}
 
 	/**
@@ -123,10 +351,10 @@ public interface WithEventBus extends Verticle {
 	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
 	 */
 	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
-			String address, Object request, Class<V> responseType
-	) {
-		return this.<T>request(address, request)
-				.map(raw -> new DecodedMessage<>(raw.body().mapTo(responseType), raw));
+			String address,
+			Object request,
+			Class<V> responseType) {
+		return DecodedMessage.compose(responseType, request(address, request));
 	}
 
 	/**
@@ -134,9 +362,65 @@ public interface WithEventBus extends Verticle {
 	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
 	 */
 	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
-			String address, JsonMessage request, DeliveryOptions options, Class<V> responseType
-	) {
-		return request(address, request.json(), options, responseType);
+			String address,
+			Object request,
+			Class<V> responseType,
+			DeliveryOptions options) {
+		return DecodedMessage.compose(responseType, request(address, request, options));
+	}
+
+	/**
+	 * @param responseType   the type of the response to map to
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
+			String address,
+			Object request,
+			Class<V> responseType,
+			DeliveryOptions options,
+			MultiMap... requestHeaders) {
+		return DecodedMessage.compose(responseType, request(address, request, options, requestHeaders));
+	}
+
+	/**
+	 * @param responseType   the type of the response to map to
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
+			String address,
+			Object request,
+			Class<V> responseType,
+			DeliveryOptions options,
+			HeaderInformation... requestHeaders) {
+		return DecodedMessage.compose(responseType, request(address, request, options, requestHeaders));
+	}
+
+	/**
+	 * @param responseType   the type of the response to map to
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
+	 */
+	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
+			String address,
+			Object request,
+			Class<V> responseType,
+			MultiMap... requestHeaders) {
+		return DecodedMessage.compose(responseType, request(address, request, requestHeaders));
+	}
+
+	/**
+	 * @param responseType   the type of the response to map to
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
+	 */
+	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
+			String address,
+			Object request,
+			Class<V> responseType,
+			HeaderInformation... requestHeaders) {
+		return DecodedMessage.compose(responseType, request(address, request, requestHeaders));
 	}
 
 	/**
@@ -144,12 +428,81 @@ public interface WithEventBus extends Verticle {
 	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
 	 */
 	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
-			String address, JsonMessage request, Class<V> responseType
-	) {
+			String address,
+			JsonMessage request,
+			Class<V> responseType) {
 		return request(address, request.json(), responseType);
 	}
 
-	/* REGISTER/CONSUME */
+	/**
+	 * @param responseType the type of the response to map to
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
+			String address,
+			JsonMessage request,
+			Class<V> responseType,
+			DeliveryOptions options) {
+		return request(address, request.json(), responseType, options);
+	}
+
+	/**
+	 * @param responseType   the type of the response to map to
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
+			String address,
+			JsonMessage request,
+			Class<V> responseType,
+			DeliveryOptions options,
+			MultiMap... requestHeaders) {
+		return request(address, request.json(), responseType, options, requestHeaders);
+	}
+
+	/**
+	 * @param responseType   the type of the response to map to
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object, DeliveryOptions)
+	 */
+	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
+			String address,
+			JsonMessage request,
+			Class<V> responseType,
+			DeliveryOptions options,
+			HeaderInformation... requestHeaders) {
+		return request(address, request.json(), responseType, options, requestHeaders);
+	}
+
+	/**
+	 * @param responseType   the type of the response to map to
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
+	 */
+	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
+			String address,
+			JsonMessage request,
+			Class<V> responseType,
+			MultiMap... requestHeaders) {
+		return request(address, request.json(), responseType, requestHeaders);
+	}
+
+	/**
+	 * @param responseType   the type of the response to map to
+	 * @param requestHeaders the headers that should be sent with the request message
+	 * @see io.vertx.core.eventbus.EventBus#request(String, Object)
+	 */
+	default <V extends JsonMessage, T extends JsonObject> Future<DecodedMessage<V, T>> request(
+			String address,
+			JsonMessage request,
+			Class<V> responseType,
+			HeaderInformation... requestHeaders) {
+		return request(address, request.json(), responseType, requestHeaders);
+	}
+
+	///
+	/// REGISTER SECTION
+	///
 
 	/**
 	 * @see io.vertx.core.eventbus.EventBus#consumer(String, Handler)
@@ -170,7 +523,10 @@ public interface WithEventBus extends Verticle {
 	 * @param type the type of received message to map to
 	 * @see io.vertx.core.eventbus.EventBus#consumer(String, Handler)
 	 */
-	default <V extends JsonMessage, T> void register(String address, ExtendedMessageHandler<V, T> handler, Class<V> type) {
+	default <V extends JsonMessage, T> void register(
+			String address,
+			ExtendedMessageHandler<V, T> handler,
+			Class<V> type) {
 		this.<T>register(address, message -> JsonMessage.on(type, message, body -> handler.handle(body, message)));
 	}
 }

--- a/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/DelayCounterInformation.java
+++ b/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/DelayCounterInformation.java
@@ -1,0 +1,71 @@
+package de.wuespace.telestion.examples.header;
+
+import de.wuespace.telestion.api.message.HeaderInformation;
+import io.vertx.core.MultiMap;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
+
+@SuppressWarnings("unused")
+public class DelayCounterInformation extends HeaderInformation {
+
+	public static final String DELAY_KEY = "delay";
+	public static final String COUNTER_KEY = "counter";
+
+	public static final int DELAY_DEFAULT_VALUE = -1;
+	public static final int COUNTER_DEFAULT_VALUE = -1;
+
+	public static DelayCounterInformation from(MultiMap headers) {
+		return new DelayCounterInformation(headers);
+	}
+
+	public static DelayCounterInformation from(Message<?> message) {
+		return new DelayCounterInformation(message);
+	}
+
+	public static DelayCounterInformation from(DeliveryOptions options) {
+		return new DelayCounterInformation(options);
+	}
+
+	public DelayCounterInformation() {
+		this(DELAY_DEFAULT_VALUE, COUNTER_DEFAULT_VALUE);
+	}
+
+	public DelayCounterInformation(int delay, int counter) {
+		setDelay(delay);
+		setCounter(counter);
+	}
+
+	public DelayCounterInformation(DelayCounterInformation other) {
+		this(other.getDelay(), other.getCounter());
+	}
+
+	public DelayCounterInformation(MultiMap headers) {
+		super(headers);
+	}
+
+	public DelayCounterInformation(Message<?> message) {
+		super(message);
+	}
+
+	public DelayCounterInformation(DeliveryOptions options) {
+		super(options);
+	}
+
+	public DelayCounterInformation setDelay(int delay) {
+		add(DELAY_KEY, delay);
+		return this;
+	}
+
+	public DelayCounterInformation setCounter(int counter) {
+		add(COUNTER_KEY, counter);
+		return this;
+	}
+
+	public int getDelay() {
+		return getInt(DELAY_KEY, DELAY_DEFAULT_VALUE);
+	}
+
+	public int getCounter() {
+		return getInt(COUNTER_KEY, COUNTER_DEFAULT_VALUE);
+	}
+}

--- a/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/Publisher.java
+++ b/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/Publisher.java
@@ -1,0 +1,46 @@
+package de.wuespace.telestion.examples.header;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.HeaderInformation;
+import de.wuespace.telestion.api.verticle.TelestionConfiguration;
+import de.wuespace.telestion.api.verticle.TelestionVerticle;
+import de.wuespace.telestion.api.verticle.trait.WithEventBus;
+import de.wuespace.telestion.api.verticle.trait.WithTiming;
+import io.vertx.core.Vertx;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SuppressWarnings("unused")
+public class Publisher extends TelestionVerticle<Publisher.Configuration> implements WithTiming, WithEventBus {
+
+	public static void main(String[] args) {
+		var vertx = Vertx.vertx();
+
+		vertx.deployVerticle(new Publisher());
+		vertx.deployVerticle(new Receiver());
+	}
+
+	public record Configuration(
+			@JsonProperty String outAddress,
+			@JsonProperty int delay
+	) implements TelestionConfiguration {
+		public Configuration() {
+			this("publish-channel", 1);
+		}
+	}
+
+	@Override
+	public void onStart() {
+		var delay = Duration.ofSeconds(getConfig().delay());
+		var counter = new AtomicInteger();
+
+		interval(delay, id -> {
+			var infos = new HeaderInformation()
+					.add("delay", getConfig().delay())
+					.add("counter", counter.getAndIncrement());
+
+			publish(getConfig().outAddress(), "Hello from Publisher", infos);
+		});
+	}
+}

--- a/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/Receiver.java
+++ b/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/Receiver.java
@@ -1,0 +1,34 @@
+package de.wuespace.telestion.examples.header;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.HeaderInformation;
+import de.wuespace.telestion.api.verticle.TelestionConfiguration;
+import de.wuespace.telestion.api.verticle.TelestionVerticle;
+import de.wuespace.telestion.api.verticle.trait.WithEventBus;
+
+@SuppressWarnings("unused")
+public class Receiver extends TelestionVerticle<Receiver.Configuration> implements WithEventBus {
+
+	public static void main(String[] args) {
+		Publisher.main(args);
+	}
+
+	public record Configuration(@JsonProperty String inAddress) implements TelestionConfiguration {
+		public Configuration() {
+			this("publish-channel");
+		}
+	}
+
+	@Override
+	public void onStart() {
+		register(getConfig().inAddress(), message -> {
+			var infos = HeaderInformation.from(message);
+			var delay = infos.getInt("delay", -1);
+			var counter = infos.getInt("counter", -1);
+
+			logger.info("Received message: {}", message.body());
+			logger.info("Publisher delay: {}", delay);
+			logger.info("Publisher counter: {}", counter);
+		});
+	}
+}

--- a/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/Requester.java
+++ b/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/Requester.java
@@ -1,0 +1,54 @@
+package de.wuespace.telestion.examples.header;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.verticle.TelestionConfiguration;
+import de.wuespace.telestion.api.verticle.TelestionVerticle;
+import de.wuespace.telestion.api.verticle.trait.WithEventBus;
+import de.wuespace.telestion.api.verticle.trait.WithTiming;
+import io.vertx.core.Vertx;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SuppressWarnings("unused")
+public class Requester extends TelestionVerticle<Requester.Configuration> implements WithTiming, WithEventBus {
+
+	public static void main(String[] args) {
+		var vertx = Vertx.vertx();
+
+		vertx.deployVerticle(new Requester());
+		vertx.deployVerticle(new Responder());
+	}
+
+	public record Configuration(
+			@JsonProperty String requestAddress,
+			@JsonProperty int delay
+	) implements TelestionConfiguration {
+		public Configuration() {
+			this("request-channel", 1);
+		}
+	}
+
+	@Override
+	public void onStart() {
+		var delay = Duration.ofSeconds(getConfig().delay());
+		var requestCounter = new AtomicInteger();
+
+		// Send a "Ping" message with custom headers periodically and request pong signal with custom headers
+		interval(delay, id -> {
+			var requestTime = System.currentTimeMillis();
+
+			var requestInfos = new DelayCounterInformation(getConfig().delay(), requestCounter.getAndIncrement());
+			var requestTimes = new TimeInformation(requestTime, requestTime);
+
+			request(getConfig().requestAddress(), "Ping", requestInfos, requestTimes).onSuccess(message -> {
+				var responseInfos = DelayCounterInformation.from(message);
+				var responseTimes = TimeInformation.from(message);
+
+				logger.info("Response body: {}", message.body());
+				logger.info("Response counter: {}", responseInfos.getCounter());
+				logger.info("Message Received on: {}", responseTimes.getReceiveTime());
+			});
+		});
+	}
+}

--- a/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/Responder.java
+++ b/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/Responder.java
@@ -1,0 +1,46 @@
+package de.wuespace.telestion.examples.header;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.wuespace.telestion.api.message.HeaderInformation;
+import de.wuespace.telestion.api.verticle.TelestionConfiguration;
+import de.wuespace.telestion.api.verticle.TelestionVerticle;
+import de.wuespace.telestion.api.verticle.trait.WithEventBus;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@SuppressWarnings("unused")
+public class Responder extends TelestionVerticle<Responder.Configuration> implements WithEventBus {
+
+	public static void main(String[] args) {
+		Requester.main(args);
+	}
+
+	public record Configuration(@JsonProperty String respondAddress) implements TelestionConfiguration {
+		public Configuration() {
+			this("request-channel");
+		}
+	}
+
+	@Override
+	public void onStart() {
+		var responseCounter = new AtomicInteger();
+
+		register(getConfig().respondAddress(), message -> {
+			var requestInfos = DelayCounterInformation.from(message);
+			var requestTimes = TimeInformation.from(message);
+
+			logger.info("Request body: {}", message.body());
+			logger.info("Request delay: {}", requestInfos.getDelay());
+			logger.info("Request counter: {}", requestInfos.getCounter());
+			logger.info("Request send time: {}", requestTimes.getSendTime());
+
+			var sendTime = System.currentTimeMillis();
+			var responseInfos = new DelayCounterInformation(
+					DelayCounterInformation.DELAY_DEFAULT_VALUE,
+					responseCounter.getAndIncrement());
+			var responseTimes = new TimeInformation(requestTimes).setSendTime(sendTime);
+
+			message.reply("Pong", HeaderInformation.merge(responseInfos, responseTimes).toOptions());
+		});
+	}
+}

--- a/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/TimeInformation.java
+++ b/modules/telestion-examples/src/main/java/de/wuespace/telestion/examples/header/TimeInformation.java
@@ -1,0 +1,72 @@
+package de.wuespace.telestion.examples.header;
+
+import de.wuespace.telestion.api.message.HeaderInformation;
+import io.vertx.core.MultiMap;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.Message;
+
+public class TimeInformation extends HeaderInformation {
+
+	public static final String RECEIVE_TIME = "receive-time";
+	public static final String SEND_TIME = "send-time";
+
+	public static final long NO_TIME = -1L;
+
+	public static TimeInformation from(MultiMap headers) {
+		return new TimeInformation(headers);
+	}
+
+	public static TimeInformation from(Message<?> message) {
+		return new TimeInformation(message);
+	}
+
+	public static TimeInformation from(DeliveryOptions options) {
+		return new TimeInformation(options);
+	}
+
+	public TimeInformation() {
+		this(System.currentTimeMillis());
+	}
+
+	public TimeInformation(long sendTime) {
+		this(NO_TIME, sendTime);
+	}
+
+	public TimeInformation(long receiveTime, long sendTime) {
+		setReceiveTime(receiveTime);
+		setSendTime(sendTime);
+	}
+
+	public TimeInformation(TimeInformation other) {
+		this(other.getReceiveTime(), other.getSendTime());
+	}
+	public TimeInformation(MultiMap headers) {
+		super(headers);
+	}
+
+	public TimeInformation(Message<?> message) {
+		super(message);
+	}
+
+	public TimeInformation(DeliveryOptions options) {
+		super(options);
+	}
+
+	public TimeInformation setReceiveTime(long receiveTime) {
+		add(RECEIVE_TIME, receiveTime);
+		return this;
+	}
+
+	public TimeInformation setSendTime(long sendTime) {
+		add(SEND_TIME, sendTime);
+		return this;
+	}
+
+	public long getReceiveTime() {
+		return getLong(RECEIVE_TIME, NO_TIME);
+	}
+
+	public long getSendTime() {
+		return getLong(SEND_TIME, NO_TIME);
+	}
+}


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

Add a Vert.x MultiMap wrapper which provides better basic type support and some conversion and extraction features for a better coding experience with Vert.x headers.

### Details <!-- Describe the content of the pull request -->

Ok, let's try that again. :smile: 

For the new Connection API, we need better type support for the already existing Vert.x MultiMap headers.
So we implemented the new `HeaderInformation` API to better support basic types.

Let's take a look.

#### Using `HeaderInformation` in your verticle

Let's say, we have the following verticle code:

```java
public class Publisher extends TelestionVerticle {
	@Override
	public void onStart() {
		vertx.setInterval(1000, id -> {
			var sendTime = System.currentTimeInMillis();

			vertx.eventBus().publish("publish-address", "Hello World");
		});
	}
}
```

It publishes "Hello World" in regular intervals onto the event bus.
Let's say, we want to publish additional information with the message, e. g. the send time on which the verticle has published the message.

With the new `HeaderInformation` API is really simple:

```java
public class Publisher extends TelestionVerticle {
	@Override
	public void onStart() {
		vertx.setInterval(1000, id -> {
			var publishInfos = new HeaderInformation()
					.add("send-time", System.currentTimeInMillis());
			
			vertx.eventBus().publish("publish-address", "Hello World", publishInfos.toOptions());
		});
	}
}
```

Now, the send time is added to the publish information and the publish information are added to the publish call on the event bus instance.

But wait, it's getting better.
Let's use the `WithEventBus` and new `WithTiming` verticle traits:

```java
public class Publisher extends TelestionVerticle implements WithEventBus, WithTiming {
	@Override
	public void onStart() {
		var delay = Duration.ofSeconds(1);

		interval(delay, id -> {
			var publishInfos = new HeaderInformation()
					.add("send-time", System.currentTimeInMillis());
			
			publish("publish-address", "Hello World", publishInfos);
		});
	}
}
```

And it's even more readable now!

The same can be done on the message receiving side:

```java
public class Receiver extends TelestionVerticle implements WithEventBus {
	@Override
	public void onStart() {
		register("publish-address", message -> {
			logger.info("Received message: {}", message.body());
		});
	}
}
```

We currently can get the send time through the `message.headers()` object and scrape out the specific key and convert it.
This can be done easier:

```java
public class Receiver extends TelestionVerticle implements WithEventBus {
	@Override
	public void onStart() {
		register("publish-address", message -> {
			var receiveInfos = HeaderInformation.from(message);
			logger.info("Received message: {}", message.body());
			logger.info("Send time: {}", receiveInfos.getLong("send-time", 0));
		});
	}
}
```

We extract the headers from the message object and now you have nice type support!

#### Writing custom header information

Let's say, you want to write your custom header information for even better usablity. That's simple!

```java
public class CounterInformation extends HeaderInformation {
	public static CounterInformation from(Message<?> message) {
		return new CounterInformation(message);
	}

	public CounterInformation(int counter) {
		add("counter", counter);
	}

	public CounterInformation(Message<?> message) {
		super(message);
	}

	public int getCounter() {
		return getInt("counter", -1);
	}
}
```

Let's extend the `HeaderInformation` API and provide a constructor which accepts a counter value and add a getter to extract the current counter value from the headers.

Now, you can use `CounterInformation` in the example from above:

```java
public class Publisher extends TelestionVerticle implements WithEventBus, WithTiming {
	@Override
	public void onStart() {
		var delay = Duration.ofSeconds(1);
		var counter = new AtomicInteger();

		interval(delay, id -> {
			var publishInfos = new HeaderInformation()
					.add("send-time", System.currentTimeInMillis());
			var counterInfos = new CounterInformation(counter.getAndIncrement());
			
			publish("publish-address", "Hello World", publishInfos, counterInfos);
		});
	}
}
```

```java
public class Receiver extends TelestionVerticle implements WithEventBus {
	@Override
	public void onStart() {
		register("publish-address", message -> {
			var receiveInfos = HeaderInformation.from(message);
			var counterInfos = CounterInformation.from(message);

			logger.info("Received message: {}", message.body());
			logger.info("Send time: {}", receiveInfos.getLong("send-time", 0));
			logger.info("Current counter: {}", counterInfos.getCounter());
		});
	}
}
```

And thats it!
Create new counter information and put it in the publish call. On the receiving side, extract it from the received message.

Another full example is provided in the examples package.

The API provides even more usability features, so please take a look at the source code or try it out in your IDE.

As always, we are open for suggestions. :wink: 

### CLA

- [x] We have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
