### PR TITLE
Fix `GenericConfiguration` throws on unknown properties

### DIFF
--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/GenericConfiguration.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/GenericConfiguration.java
@@ -1,5 +1,7 @@
 package de.wuespace.telestion.api.verticle;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * The type of configuration for a {@link TelestionVerticle} that you use
  * to indicate that the verticle does not have a strictly typed configuration.
@@ -7,5 +9,6 @@ package de.wuespace.telestion.api.verticle;
  * @author Pablo Klaschka (@pklaschka), Ludwig Richter (@fussel178)
  * @see TelestionVerticle#getConfig()
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record GenericConfiguration() implements TelestionConfiguration {
 }


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

A generic or raw configuration should not throw an exception on unknown properties in the JSON object. Lets fix that. :wink: 

### Details <!-- Describe the content of the pull request -->

Add the `@JsonIgnoreProperties` annotation to the `GenericConfiguration` record.

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
