### PR TITLE
[AppRewrite] Part 3: Loaders and Deployments

### DIFF
--- a/modules/telestion-application/build.gradle
+++ b/modules/telestion-application/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.0.1'
 
     implementation "io.vertx:vertx-core:4.2.5"
+
+    implementation project(':modules:telestion-api')
 }
 
 test {

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/deployment/Deployment.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/deployment/Deployment.java
@@ -1,0 +1,333 @@
+package de.wuespace.telestion.application.deployment;
+
+import de.wuespace.telestion.application.launcher.LoaderLauncher;
+import de.wuespace.telestion.application.loader.Loader;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Verticle;
+
+import java.util.Objects;
+
+/**
+ * A {@link Deployment} represents a {@link Verticle} in a {@link io.vertx.core.Vertx Vertx} instance.
+ * <p>
+ * The {@link Verticle} can be deployed and un-deployed on the {@link io.vertx.core.Vertx Vertx} instance.
+ * <p>
+ * A {@link Verticle} can be represented by:
+ * <ul>
+ *     <li>a {@link Verticle} instance</li>
+ *     <li>a {@link Class} type</li>
+ *     <li>a classname which points the the verticle class</li>
+ * </ul>
+ * (see {@link DeploymentType})
+ *
+ * @author Ludwig Richter (@fussel178)
+ * @see io.vertx.core.Vertx
+ */
+public class Deployment {
+
+	/**
+	 * A reference to the {@link LoaderLauncher} which holds the {@link Deployment Deployments}.
+	 */
+	private final LoaderLauncher launcher;
+
+	/**
+	 * Is one of the 3 deployment types (see {@link DeploymentType}).
+	 * <p>
+	 * Contains the verticle {@link Class} type.
+	 */
+	private final Class<? extends Verticle> verticleClass;
+
+	/**
+	 * Is one of the 3 deployment types (see {@link DeploymentType}).
+	 * <p>
+	 * Contains an instance of a verticle.
+	 */
+	private final Verticle verticle;
+
+	/**
+	 * Is one of the 3 deployment types (see {@link DeploymentType}).
+	 * <p>
+	 * Contains the classname to a verticle class.
+	 */
+	private final String className;
+
+	/**
+	 * Deployment options that the verticle receives during deployment on the
+	 * {@link io.vertx.core.Vertx Vertx} instance.
+	 */
+	private final DeploymentOptions options;
+
+	/**
+	 * Contains the deployment id of the verticle on the {@link io.vertx.core.Vertx Vertx} instance.
+	 * Is {@code null} when the verticle in this deployment is currently not deployed.
+	 */
+	private String deploymentId = null;
+
+	private Deployment(
+			LoaderLauncher launcher,
+			Class<? extends Verticle> verticleClass,
+			Verticle verticle,
+			String className,
+			DeploymentOptions options) {
+
+		this.launcher = launcher;
+		this.verticleClass = verticleClass;
+		this.verticle = verticle;
+		this.className = className;
+		this.options = options;
+	}
+
+	/**
+	 * Like {@link #Deployment(LoaderLauncher, Class)} but with {@link DeploymentOptions}.
+	 * <p>
+	 * These deployment options receive the {@link Verticle} instance on deployment.
+	 *
+	 * @param launcher      the launcher that controls the {@link io.vertx.core.Vertx Vertx} instance
+	 * @param verticleClass the class type of the {@link Verticle verticle} that you want deploy
+	 * @param options       deployment options for your running verticle
+	 */
+	public Deployment(LoaderLauncher launcher, Class<? extends Verticle> verticleClass, DeploymentOptions options) {
+		this(launcher, verticleClass, null, null, options);
+	}
+
+	/**
+	 * Like {@link #Deployment(LoaderLauncher, Verticle)} but the {@link Verticle} instance is created
+	 * by invoking the default constructor.
+	 *
+	 * @param launcher      the launcher that controls the {@link io.vertx.core.Vertx Vertx} instance
+	 * @param verticleClass the class type of the {@link Verticle verticle} that you want deploy
+	 */
+	public Deployment(LoaderLauncher launcher, Class<? extends Verticle> verticleClass) {
+		this(launcher, verticleClass, new DeploymentOptions());
+	}
+
+	/**
+	 * Like {@link #Deployment(LoaderLauncher, Verticle)} but with {@link DeploymentOptions}.
+	 * <p>
+	 * These deployment options receive the {@link Verticle} instance on deployment.
+	 *
+	 * @param launcher the launcher that controls the {@link io.vertx.core.Vertx Vertx} instance
+	 * @param verticle your verticle instance that you want to deploy
+	 * @param options  deployment options for your running verticle
+	 */
+	public Deployment(LoaderLauncher launcher, Verticle verticle, DeploymentOptions options) {
+		this(launcher, null, verticle, null, options);
+	}
+
+	/**
+	 * Creates a new deployment instance with a verticle instance that you create by yourself.
+	 *
+	 * @param launcher the launcher that controls the {@link io.vertx.core.Vertx Vertx} instance
+	 * @param verticle your verticle instance that you want to deploy
+	 */
+	public Deployment(LoaderLauncher launcher, Verticle verticle) {
+		this(launcher, verticle, new DeploymentOptions());
+	}
+
+	/**
+	 * Like {@link #Deployment(LoaderLauncher, String)} but with {@link DeploymentOptions}.
+	 * <p>
+	 * These deployment options receive the {@link Verticle} instance on deployment.
+	 *
+	 * @param launcher  the launcher that controls the {@link io.vertx.core.Vertx Vertx} instance
+	 * @param className the classname or binary name of your {@link Verticle verticle} class
+	 * @param options   deployment options for your running verticle
+	 */
+	public Deployment(LoaderLauncher launcher, String className, DeploymentOptions options) {
+		this(launcher, null, null, className, options);
+	}
+
+	/**
+	 * Like {@link #Deployment(LoaderLauncher, Verticle)} but the {@link Verticle verticle} instance is created
+	 * by a {@link io.vertx.core.spi.VerticleFactory verticle factory} based on the classname.
+	 *
+	 * @param launcher  the launcher that controls the {@link io.vertx.core.Vertx Vertx} instance
+	 * @param className the classname or binary name of your {@link Verticle verticle} class
+	 */
+	public Deployment(LoaderLauncher launcher, String className) {
+		this(launcher, className, new DeploymentOptions());
+	}
+
+	/**
+	 * Get the {@link DeploymentType} based on the given parameters in the constructor.
+	 *
+	 * @return the deployment type of this instance
+	 */
+	public DeploymentType getDeploymentType() {
+		if (Objects.nonNull(verticleClass)) {
+			return DeploymentType.CLASS_TYPE;
+		} else if (Objects.nonNull(verticle)) {
+			return DeploymentType.INSTANCE;
+		} else if (Objects.nonNull(className)) {
+			return DeploymentType.CLASS_NAME;
+		} else {
+			throw new IllegalStateException("Unexpected state entered while trying to determine deployment type. " +
+					"Sorry for the inconvenience. There should only constructors exist that should set at least one " +
+					"specific deployment member. Please help us fix the mistake by filing an issue at " +
+					"https://github.com/wuespace/telestion-core/issues/new and include the entire error message " +
+					"(including the details below) and we'll have a look as soon as we can. Details: " + this);
+		}
+	}
+
+	/**
+	 * Is {@code true} when the verticle runs on the {@link io.vertx.core.Vertx Vertx} instance.
+	 *
+	 * @return {@code true} when the verticle is deployed
+	 */
+	public boolean isDeployed() {
+		return Objects.nonNull(deploymentId);
+	}
+
+	/**
+	 * Get a reference to the {@link LoaderLauncher} instance that holds this deployment and controls the
+	 * {@link io.vertx.core.Vertx Vertx} instance.
+	 *
+	 * @return a reference to the associated launcher instance
+	 */
+	public LoaderLauncher getLauncher() {
+		return launcher;
+	}
+
+	/**
+	 * Get the {@link Class} type of the verticle.
+	 * <p>
+	 * Can be {@code null} depending on the given parameters in the constructor.
+	 * Check first with {@link #getDeploymentType()} if the deployment type is a {@link DeploymentType#CLASS_TYPE}
+	 * before continuing.
+	 *
+	 * @return the {@link Class} type of the verticle
+	 */
+	public Class<? extends Verticle> getVerticleClass() {
+		return verticleClass;
+	}
+
+	/**
+	 * Get the verticle instance.
+	 * <p>
+	 * Can be {@code null} depending on the given parameters in the constructor.
+	 * Check first with {@link #getDeploymentType()} if the deployment type is a {@link DeploymentType#INSTANCE}
+	 * before continuing.
+	 *
+	 * @return the verticle instance
+	 */
+	public Verticle getVerticle() {
+		return verticle;
+	}
+
+	/**
+	 * Get the classname or binary name of the verticle class.
+	 * <p>
+	 * Can be {@code null} depending on the given parameters in the constructor.
+	 * Check first with {@link #getDeploymentType()} if the deployment type is a {@link DeploymentType#CLASS_NAME}
+	 * before continuing.
+	 *
+	 * @return the classname or binary name of the verticle class
+	 */
+	public String getClassName() {
+		return className;
+	}
+
+	/**
+	 * Get the deployment options that receives the {@link Verticle} instance on deployment
+	 *
+	 * @return the deployment options for the verticle instance
+	 */
+	public DeploymentOptions getDeploymentOptions() {
+		return options;
+	}
+
+	/**
+	 * Get the deployment id of the verticle in the {@link io.vertx.core.Vertx Vertx} instance.
+	 * <p>
+	 * Can be {@code null} when the verticle is not deployed yet.
+	 *
+	 * @return the deployment id of the verticle in the Vertx instance
+	 */
+	public String getDeploymentId() {
+		return deploymentId;
+	}
+
+	/**
+	 * Deploys this deployment on the {@link io.vertx.core.Vertx Vertx} instance
+	 * controlled by the {@link LoaderLauncher}.
+	 *
+	 * @return a future which resolves when this instance successfully deploys
+	 */
+	public Future<Deployment> deploy() {
+		var loaders = launcher.getLoaders();
+
+		// 1 - call before verticle deploy event
+		return Future.future(promise -> Loader.call(loaders, (loader, loaderPromise) -> loader.onBeforeVerticleDeploy(loaderPromise, this))
+				// 2 - deploy verticle on Vert.x instance
+				.compose(result -> deployVerticle())
+				// 3 - call after verticle deploy event
+				.compose(result -> Loader.call(loaders, (loader, loaderPromise) -> loader.onAfterVerticleDeploy(loaderPromise, this)))
+				// return instance to satisfy promise
+				.map(result -> this).onComplete(promise));
+	}
+
+	/**
+	 * Un-deploys this deployment from the {@link io.vertx.core.Vertx Vertx} instance
+	 * controlled by the {@link LoaderLauncher}.
+	 *
+	 * @return a future which resolves when this instance successfully un-deploys
+	 */
+	public Future<Deployment> undeploy() {
+		var loaders = launcher.getLoaders();
+
+		// 1 - call before verticle undeploy event
+		return Future.future(promise -> Loader.call(loaders, (loader, loaderPromise) -> loader.onBeforeVerticleUndeploy(loaderPromise, this))
+				// 2 - undeploy verticle on Vert.x instance
+				.compose(result -> undeployVerticle())
+				// 3 - call after verticle undeploy event
+				.compose(result -> Loader.call(loaders, (loader, loaderPromise) -> loader.onAfterVerticleUndeploy(loaderPromise, this)))
+				// return instance to satisfy promise
+				.map(result -> this).onComplete(promise));
+	}
+
+	/**
+	 * Deploys the verticle on the associated {@link #launcher}.
+	 *
+	 * @return a future which resolves with the deployment id when the verticle successfully deploys
+	 */
+	private Future<String> deployVerticle() {
+		var vertx = launcher.getVertx();
+
+		var future = switch (getDeploymentType()) {
+			case CLASS_TYPE -> vertx.deployVerticle(verticleClass, options);
+			case INSTANCE -> vertx.deployVerticle(verticle, options);
+			case CLASS_NAME -> vertx.deployVerticle(className, options);
+		};
+
+		return future.onSuccess(this::setDeploymentId);
+	}
+
+	/**
+	 * Un-deploys the verticle from the associated {@link #launcher}.
+	 *
+	 * @return a future which resolves when the verticle successfully un-deploys
+	 */
+	private Future<Void> undeployVerticle() {
+		// fail fast if verticle is not deployed
+		if (!isDeployed()) return Future.failedFuture("Not deployed");
+
+		return launcher.getVertx().undeploy(deploymentId).onSuccess(this::clearDeploymentId);
+	}
+
+	/**
+	 * Set the deployment id of the verticle in the {@link io.vertx.core.Vertx Vertx} instance.
+	 *
+	 * @param deploymentId the new deployment id
+	 */
+	private void setDeploymentId(String deploymentId) {
+		this.deploymentId = deploymentId;
+	}
+
+	/**
+	 * Remove the deployment id in this instance.
+	 */
+	private void clearDeploymentId(Void result) {
+		setDeploymentId(null);
+	}
+}

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/deployment/DeploymentType.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/deployment/DeploymentType.java
@@ -23,6 +23,7 @@ package de.wuespace.telestion.application.deployment;
  *         <td>{@link #CLASS_NAME}</td>
  *         <td>a classname of binary name of a verticle class</td>
  *     </tr>
+ *     <caption>Associated deployment types and available information in the {@link Deployment}</caption>
  * </table>
  *
  * @author Ludwig Richter (@fussel178)

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/deployment/DeploymentType.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/deployment/DeploymentType.java
@@ -1,0 +1,45 @@
+package de.wuespace.telestion.application.deployment;
+
+/**
+ * The {@link DeploymentType} specifies which information the {@link Deployment} has
+ * to deploy a verticle on a {@link io.vertx.core.Vertx Vertx} instance.
+ *
+ * The following types are supported:
+ *
+ * <table>
+ *     <tr>
+ *         <th>Deployment type</th>
+ *         <th>associated information</th>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link #INSTANCE}</td>
+ *         <td>a {@link io.vertx.core.Verticle Verticle} instance</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link #CLASS_TYPE}</td>
+ *         <td>a verticle {@link Class} type</td>
+ *     </tr>
+ *     <tr>
+ *         <td>{@link #CLASS_NAME}</td>
+ *         <td>a classname of binary name of a verticle class</td>
+ *     </tr>
+ * </table>
+ *
+ * @author Ludwig Richter (@fussel178)
+ */
+public enum DeploymentType {
+	/**
+	 * Represents a verticle {@link Class} type as information in the {@link Deployment}.
+	 */
+	CLASS_TYPE,
+	/**
+	 * Represents a {@link io.vertx.core.Verticle Verticle} instance as information
+	 * in the {@link Deployment}.
+	 */
+	INSTANCE,
+	/**
+	 * Represents a classname of binary name of a verticle class as information
+	 * in the {@link Deployment}.
+	 */
+	CLASS_NAME
+}

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/ConfigDeploymentLauncher.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/ConfigDeploymentLauncher.java
@@ -1,0 +1,9 @@
+package de.wuespace.telestion.application.launcher;
+
+/**
+ * This launcher combines the functionality of a {@link ConfigLauncher} and a {@link DeploymentLauncher}.
+ *
+ * @author Ludwig Richter (@fussel178)
+ */
+public interface ConfigDeploymentLauncher<T> extends ConfigLauncher<T>, DeploymentLauncher {
+}

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/ConfigDeploymentLauncher.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/ConfigDeploymentLauncher.java
@@ -1,7 +1,8 @@
 package de.wuespace.telestion.application.launcher;
 
 /**
- * This launcher combines the functionality of a {@link ConfigLauncher} and a {@link DeploymentLauncher}.
+ * This launcher type combines the functionality of a {@link ConfigLauncher} type
+ * and a {@link DeploymentLauncher} type.
  *
  * @author Ludwig Richter (@fussel178)
  */

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/DeploymentLauncher.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/DeploymentLauncher.java
@@ -8,7 +8,7 @@ import io.vertx.core.Verticle;
 import java.util.List;
 
 /**
- * An extended version of the {@link LoaderLauncher}.
+ * An extended version of the {@link LoaderLauncher} type.
  * <p>
  * It provides support for deploying {@link Verticle Verticles} onto the {@link io.vertx.core.Vertx Vertx} instance
  * of the {@link VertxLauncher}. A {@link Deployment} is used to represent the running

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/DeploymentLauncher.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/DeploymentLauncher.java
@@ -1,0 +1,37 @@
+package de.wuespace.telestion.application.launcher;
+
+import de.wuespace.telestion.application.deployment.Deployment;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Verticle;
+
+import java.util.List;
+
+/**
+ * An extended version of the {@link LoaderLauncher}.
+ * <p>
+ * It provides support for deploying {@link Verticle Verticles} onto the {@link io.vertx.core.Vertx Vertx} instance
+ * of the {@link VertxLauncher}. A {@link Deployment} is used to represent the running
+ * {@link Verticle verticle} on the Vertx instance.
+ *
+ * @author Ludwig Richter (@fussel178)
+ * @see LoaderLauncher
+ * @see Deployment
+ */
+public interface DeploymentLauncher extends LoaderLauncher {
+
+	/**
+	 * Add a deployment to the deployment list of the launcher instance.
+	 *
+	 * @param deployment the deployment that you want to add
+	 * @return the added deployment for further usage
+	 */
+	Deployment addDeployment(Deployment deployment);
+
+	/**
+	 * Get the current deployments on this launcher instance.
+	 *
+	 * @return the current deployments
+	 */
+	List<Deployment> getDeployments();
+}

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/LoaderLauncher.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/LoaderLauncher.java
@@ -5,7 +5,7 @@ import de.wuespace.telestion.application.loader.Loader;
 import java.util.List;
 
 /**
- * An extended version of the {@link VertxLauncher}.
+ * An extended version of the {@link VertxLauncher} type.
  * <p>
  * The launcher uses {@link Loader Loaders} to run user defined hooks on Launcher and
  * {@link io.vertx.core.Vertx Vertx} events.

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/LoaderLauncher.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/launcher/LoaderLauncher.java
@@ -1,0 +1,25 @@
+package de.wuespace.telestion.application.launcher;
+
+import de.wuespace.telestion.application.loader.Loader;
+
+import java.util.List;
+
+/**
+ * An extended version of the {@link VertxLauncher}.
+ * <p>
+ * The launcher uses {@link Loader Loaders} to run user defined hooks on Launcher and
+ * {@link io.vertx.core.Vertx Vertx} events.
+ *
+ * @author Ludwig Richter (@fussel178)
+ * @see VertxLauncher
+ * @see Loader
+ */
+public interface LoaderLauncher extends VertxLauncher {
+
+	/**
+	 * Get a list of loaders that contain the user defined hooks.
+	 *
+	 * @return a list of loaders with user defined hooks
+	 */
+	List<Loader<?>> getLoaders();
+}

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/EventSelector.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/EventSelector.java
@@ -1,0 +1,23 @@
+package de.wuespace.telestion.application.loader;
+
+import io.vertx.core.Promise;
+
+import java.util.List;
+
+/**
+ * Selects and executes an event handler on a {@link Loader}.
+ *
+ * @author Ludwig Richter (@fussel178)
+ * @see Loader#call(List, EventSelector)
+ */
+@FunctionalInterface
+public interface EventSelector {
+	/**
+	 * Selects and executes an event handler on a {@link Loader}.
+	 *
+	 * @param loader  the loader which provides the selected event handler
+	 * @param promise a promise which receives the selected event handler
+	 * @see Loader#call(List, EventSelector)
+	 */
+	void handle(Loader<?> loader, Promise<Void> promise) throws Exception;
+}

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/EventSelector.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/EventSelector.java
@@ -14,6 +14,22 @@ import java.util.List;
 public interface EventSelector {
 	/**
 	 * Selects and executes an event handler on a {@link Loader}.
+	 * <p>
+	 * For example:
+	 * <pre>
+	 * {@code
+	 * // here is your loader list
+	 * List<Loader> loaders;
+	 *
+	 * // the Event Selector is basically a lambda function which selects the event
+	 * // on a loader that you want to call
+	 * Loader.call(loaders, (loader, promise) -> loader.onBeforeVertxStartup(promise));
+	 *
+	 * // due to the nature of both definitions, you can use the double-colon operator (::)
+	 * // or method reference
+	 * Loader.call(loaders, Loader::onBeforeVertxStartup);
+	 * }
+	 * </pre>
 	 *
 	 * @param loader  the loader which provides the selected event handler
 	 * @param promise a promise which receives the selected event handler

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/Loader.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/Loader.java
@@ -76,7 +76,7 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	 * The selector receives the loader and a promise for the event handler of the loader.
 	 * It "specifies" the event handler that should be called.
 	 *
-	 * <h2>Usage</h2>
+	 * <h4>Usage</h4>
 	 * <pre>
 	 * {@code
 	 * Loader.call(loaders, Loader::onBeforeVertxStartup)

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/Loader.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/Loader.java
@@ -52,20 +52,20 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 					"classname, install required packages and try again.").formatted(className), e.getException());
 		} catch (InvocationTargetException e) {
 			throw new InvocationTargetException(e.getTargetException(), ("The loader %s cannot be created because " +
-					"the constructor throws an exception during instantiation. Please check your loaders " +
+					"the constructor throws an exception during instantiation. Please check your loader's " +
 					"constructor, fix the breaking code and try again.").formatted(className));
 		} catch (InstantiationException e) {
 			throw new InstantiationException(("Abstract loaders aren't supported. Please extend the \"Loader\" " +
 					"class in loader %s, add the sub class to the configuration and try again.").formatted(className));
 		} catch (IllegalAccessException e) {
 			throw new IllegalAccessException(("The class loader cannot instantiate the loader %s because " +
-					"the constructor is inaccessible. Please add at least one public constructor with no arguments " +
+					"the constructor is inaccessible. Please add a public constructor with no arguments " +
 					"to continue.").formatted(className));
 		} catch (NoSuchMethodException e) {
 			throw new NoSuchMethodException("The loader %s does not contain a constructor. Please add one to continue."
 					.formatted(className));
 		} catch (ClassCastException e) {
-			throw new ClassCastException(("The given class behind the classname %s is not a loader. Please implement " +
+			throw new ClassCastException(("The given class behind the classname %s isn't a loader. Please implement " +
 					"the \"Loader\" interface in your loader and try again.").formatted(className));
 		}
 	}
@@ -130,12 +130,12 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void init(ConfigDeploymentLauncher<? extends JsonObject> launcher);
 
 	/**
-	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} initializes itself, but before it parses
+	 * Gets called after the {@link ConfigDeploymentLauncher Launcher} initializes itself, but before it parses
 	 * the {@link io.vertx.core.VertxOptions VertxOptions} from the main configuration.
 	 * <p>
-	 * Use this event if you want to run initialization steps that aren't depend on Vertx options or an instance.
+	 * Use this event if you want to run initialization steps that don't depend on Vertx options or an instance.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -150,13 +150,13 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onInit(Promise<Void> startPromise) throws Exception;
 
 	/**
-	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} parses the
+	 * Gets called after the {@link ConfigDeploymentLauncher Launcher} parses the
 	 * {@link io.vertx.core.VertxOptions VertxOptions}, but before it creates the
 	 * {@link io.vertx.core.Vertx Vertx} instance.
 	 * <p>
 	 * Use this event if you want to run startup steps that depend on the Vertx options but not on a running instance.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -171,12 +171,12 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onBeforeVertxStartup(Promise<Void> startPromise) throws Exception;
 
 	/**
-	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} creates a
+	 * Gets called after the {@link ConfigDeploymentLauncher Launcher} creates a
 	 * {@link io.vertx.core.Vertx Vertx} instance and is ready to complete the startup process.
 	 * <p>
 	 * Use this event if you want to run startup steps that depend on a running Vertx instance.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -191,12 +191,12 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onAfterVertxStartup(Promise<Void> startPromise) throws Exception;
 
 	/**
-	 * Gets called, before the {@link ConfigDeploymentLauncher Launcher} closes the running
+	 * Gets called before the {@link ConfigDeploymentLauncher Launcher} closes the running
 	 * {@link io.vertx.core.Vertx Vertx} instance.
 	 * <p>
 	 * Use this event if you want to run shutdown steps that depend on a running Vertx instance.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -211,14 +211,14 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onBeforeVertxShutdown(Promise<Void> stopPromise) throws Exception;
 
 	/**
-	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} closes the
+	 * Gets called after the {@link ConfigDeploymentLauncher Launcher} closes the
 	 * {@link io.vertx.core.Vertx Vertx} instance, but before it removes the instance and the related
 	 * {@link io.vertx.core.VertxOptions VertxOptions}.
 	 * <p>
-	 * Use this event if you want to run shutdown steps that aren't depend on a running Vertx instance but running
-	 * before the exit step.
+	 * Use this event if you want to run shutdown steps that don't depend on a running Vertx instance but you want
+	 * it to run before the exit step.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -233,12 +233,12 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onAfterVertxShutdown(Promise<Void> stopPromise) throws Exception;
 
 	/**
-	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} removes the {@link io.vertx.core.Vertx Vertx}
+	 * Gets called after the {@link ConfigDeploymentLauncher Launcher} removes the {@link io.vertx.core.Vertx Vertx}
 	 * instance and {@link io.vertx.core.VertxOptions VertxOptions} and is ready to complete the shutdown process.
 	 * <p>
 	 * Use this event if you want to run shutdown steps that should run directly before the launcher stops.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -253,12 +253,12 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onExit(Promise<Void> stopPromise) throws Exception;
 
 	/**
-	 * Gets called, before the {@link ConfigDeploymentLauncher Launcher} deploys a new
+	 * Gets called before the {@link ConfigDeploymentLauncher Launcher} deploys a new
 	 * {@link io.vertx.core.Verticle Verticle}.
 	 * <p>
 	 * Use this event if you want to run steps before a verticle deploys.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution. A failed promise <strong>prevents</strong> the verticle from deploying.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -273,12 +273,12 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onBeforeVerticleDeploy(Promise<Void> completePromise, Deployment deployment) throws Exception;
 
 	/**
-	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} deploys a new
+	 * Gets called after the {@link ConfigDeploymentLauncher Launcher} deploys a new
 	 * {@link io.vertx.core.Verticle Verticle}.
 	 * <p>
 	 * Use this event if you want to run steps after a verticle deploys.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -293,12 +293,12 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onAfterVerticleDeploy(Promise<Void> completePromise, Deployment deployment) throws Exception;
 
 	/**
-	 * Gets called, before the {@link ConfigDeploymentLauncher Launcher} un-deploys a running
+	 * Gets called before the {@link ConfigDeploymentLauncher Launcher} un-deploys a running
 	 * {@link io.vertx.core.Verticle Verticle}.
 	 * <p>
 	 * Use this event if you want to run steps before a verticle un-deploys.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution. A failed promise <strong>prevents</strong> the verticle from un-deploying.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -313,12 +313,12 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onBeforeVerticleUndeploy(Promise<Void> completePromise, Deployment deployment) throws Exception;
 
 	/**
-	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} un-deploys a running
+	 * Gets called after the {@link ConfigDeploymentLauncher Launcher} un-deploys a running
 	 * {@link io.vertx.core.Verticle Verticle}.
 	 * <p>
 	 * Use this event if you want to run steps after a verticle un-deploys.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution. A failed promise <strong>prevents</strong> the verticle from un-deploying.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
@@ -333,12 +333,12 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	void onAfterVerticleUndeploy(Promise<Void> completePromise, Deployment deployment) throws Exception;
 
 	/**
-	 * Gets called, when the running {@link io.vertx.core.Vertx Vertx} instance in the
+	 * Gets called when the running {@link io.vertx.core.Vertx Vertx} instance in the
 	 * {@link ConfigDeploymentLauncher Launcher} encounters an uncaught exception.
 	 * <p>
 	 * Use this event if you want to run steps on uncaught exception on the Vertx instance.
 	 * <p>
-	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
 	 * an error during execution.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/Loader.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/Loader.java
@@ -1,0 +1,350 @@
+package de.wuespace.telestion.application.loader;
+
+import de.wuespace.telestion.api.DefaultConfigurable;
+import de.wuespace.telestion.application.deployment.Deployment;
+import de.wuespace.telestion.application.launcher.ConfigDeploymentLauncher;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A loader is a collection of event handlers that hook into different processes of the associated
+ * {@link ConfigDeploymentLauncher Launcher}.
+ * <p>
+ * It can register event handlers in:
+ * <ul>
+ *     <li>the startup and shutdown process of the loader</li>
+ *     <li>the {@link io.vertx.core.Verticle Verticle} deployment and un-deployment</li>
+ *     <li>the Vertx exception handling</li>
+ * </ul>
+ * <p>
+ * To start, take a look at the {@link TelestionLoader} as an abstract reference implementation.
+ *
+ * @param <T> the type of the loader configuration
+ * @author Ludwig Richter (@fussel178)
+ * @see TelestionLoader
+ * @see LoaderConfiguration
+ * @see ConfigDeploymentLauncher
+ */
+public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurable<T> {
+
+	/**
+	 * Instantiates a new loader from a given classname.
+	 *
+	 * @param className the classname or binary name of the loader class
+	 * @return the loader instance associated to the classname
+	 */
+	static Loader<?> instantiate(String className)
+			throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException,
+			NoSuchMethodException, ClassCastException {
+
+		try {
+			var classLoader = Loader.class.getClassLoader();
+			var loaderClass = classLoader.loadClass(className);
+			return (Loader<?>) loaderClass.getConstructor().newInstance();
+		} catch (ClassNotFoundException e) {
+			throw new ClassNotFoundException(("Cannot find loader with classname %s. Please check the given " +
+					"classname, install required packages and try again.").formatted(className), e.getException());
+		} catch (InvocationTargetException e) {
+			throw new InvocationTargetException(e.getTargetException(), ("The loader %s cannot be created because " +
+					"the constructor throws an exception during instantiation. Please check your loaders " +
+					"constructor, fix the breaking code and try again.").formatted(className));
+		} catch (InstantiationException e) {
+			throw new InstantiationException(("Abstract loaders aren't supported. Please extend the \"Loader\" " +
+					"class in loader %s, add the sub class to the configuration and try again.").formatted(className));
+		} catch (IllegalAccessException e) {
+			throw new IllegalAccessException(("The class loader cannot instantiate the loader %s because " +
+					"the constructor is inaccessible. Please add at least one public constructor with no arguments " +
+					"to continue.").formatted(className));
+		} catch (NoSuchMethodException e) {
+			throw new NoSuchMethodException("The loader %s does not contain a constructor. Please add one to continue."
+					.formatted(className));
+		} catch (ClassCastException e) {
+			throw new ClassCastException(("The given class behind the classname %s is not a loader. Please implement " +
+					"the \"Loader\" interface in your loader and try again.").formatted(className));
+		}
+	}
+
+	/**
+	 * Calls a selected event handler on a list of loaders.
+	 * <p>
+	 * The selector receives the loader and a promise for the event handler of the loader.
+	 * It "specifies" the event handler that should be called.
+	 *
+	 * <h2>Usage</h2>
+	 * <pre>
+	 * {@code
+	 * Loader.call(loaders, Loader::onBeforeVertxStartup)
+	 * 	.onSuccess(result -> logger.info("Loaders called"));
+	 * }
+	 * </pre>
+	 *
+	 * @param loaders  the list of loaders on which the event handler should be called
+	 * @param selector the selector which selects the event handler that should be called
+	 * @return a future which resolves when all loaders resolve
+	 */
+	static Future<CompositeFuture> call(List<Loader<?>> loaders, EventSelector selector) {
+		return CompositeFuture.join(loaders.stream().map(loader -> Future.<Void>future(promise -> {
+			try {
+				selector.handle(loader, promise);
+			} catch (Exception e) {
+				promise.tryFail(e);
+			}
+		})).collect(Collectors.toList()));
+	}
+
+	/**
+	 * Returns a reference to the {@link ConfigDeploymentLauncher Launcher} instance which deployed this loader.
+	 *
+	 * @return the associated {@link ConfigDeploymentLauncher Launcher} instance
+	 */
+	ConfigDeploymentLauncher<? extends JsonObject> getLauncher();
+
+	/**
+	 * Set the current loader configuration.
+	 *
+	 * @param config the loader configuration
+	 */
+	void setConfig(JsonObject config);
+
+	/**
+	 * Set the current loader configuration.
+	 *
+	 * @param config the loader configuration
+	 */
+	void setConfig(T config);
+
+	/**
+	 * Initializes the loader with the associated {@link ConfigDeploymentLauncher Launcher} instance
+	 * which deployed this loader.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 *
+	 * @param launcher the Telestion Launcher which deployed this loader
+	 */
+	void init(ConfigDeploymentLauncher<? extends JsonObject> launcher);
+
+	/**
+	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} initializes itself, but before it parses
+	 * the {@link io.vertx.core.VertxOptions VertxOptions} from the main configuration.
+	 * <p>
+	 * Use this event if you want to run initialization steps that aren't depend on Vertx options or an instance.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * <strong><code>onInit</code></strong> ➔
+	 * {@link #onBeforeVertxStartup(Promise) onBeforeVertxStartup} ➔
+	 * {@link #onAfterVertxStartup(Promise) onAfterVertxStartup}
+	 *
+	 * @param startPromise the promise that indicates the completion state of this loader
+	 */
+	void onInit(Promise<Void> startPromise) throws Exception;
+
+	/**
+	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} parses the
+	 * {@link io.vertx.core.VertxOptions VertxOptions}, but before it creates the
+	 * {@link io.vertx.core.Vertx Vertx} instance.
+	 * <p>
+	 * Use this event if you want to run startup steps that depend on the Vertx options but not on a running instance.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * {@link #onInit(Promise) onInit} ➔
+	 * <strong><code>onBeforeVertxStartup</code></strong> ➔
+	 * {@link #onAfterVertxStartup(Promise) onAfterVertxStartup}
+	 *
+	 * @param startPromise the promise that indicates the completion state of this loader
+	 */
+	void onBeforeVertxStartup(Promise<Void> startPromise) throws Exception;
+
+	/**
+	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} creates a
+	 * {@link io.vertx.core.Vertx Vertx} instance and is ready to complete the startup process.
+	 * <p>
+	 * Use this event if you want to run startup steps that depend on a running Vertx instance.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * {@link #onInit(Promise) onInit} ➔
+	 * {@link #onBeforeVertxStartup(Promise) onBeforeVertxStartup} ➔
+	 * <strong><code>onAfterVertxStartup</code></strong>
+	 *
+	 * @param startPromise the promise that indicates the completion state of this loader
+	 */
+	void onAfterVertxStartup(Promise<Void> startPromise) throws Exception;
+
+	/**
+	 * Gets called, before the {@link ConfigDeploymentLauncher Launcher} closes the running
+	 * {@link io.vertx.core.Vertx Vertx} instance.
+	 * <p>
+	 * Use this event if you want to run shutdown steps that depend on a running Vertx instance.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * <strong><code>onBeforeVertxShutdown</code></strong> ➔
+	 * {@link #onAfterVertxShutdown(Promise) onAfterVertxShutdown} ➔
+	 * {@link #onExit(Promise) onExit}
+	 *
+	 * @param stopPromise the promise that indicates the completion state of this loader
+	 */
+	void onBeforeVertxShutdown(Promise<Void> stopPromise) throws Exception;
+
+	/**
+	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} closes the
+	 * {@link io.vertx.core.Vertx Vertx} instance, but before it removes the instance and the related
+	 * {@link io.vertx.core.VertxOptions VertxOptions}.
+	 * <p>
+	 * Use this event if you want to run shutdown steps that aren't depend on a running Vertx instance but running
+	 * before the exit step.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * {@link #onBeforeVertxShutdown(Promise) onBeforeVertxShutdown} ➔
+	 * <strong><code>onAfterVertxShutdown</code></strong> ➔
+	 * {@link #onExit(Promise) onExit}
+	 *
+	 * @param stopPromise the promise that indicates the completion state of this loader
+	 */
+	void onAfterVertxShutdown(Promise<Void> stopPromise) throws Exception;
+
+	/**
+	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} removes the {@link io.vertx.core.Vertx Vertx}
+	 * instance and {@link io.vertx.core.VertxOptions VertxOptions} and is ready to complete the shutdown process.
+	 * <p>
+	 * Use this event if you want to run shutdown steps that should run directly before the launcher stops.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * {@link #onBeforeVertxShutdown(Promise) onBeforeVertxShutdown} ➔
+	 * {@link #onAfterVertxShutdown(Promise) onAfterVertxShutdown} ➔
+	 * <strong><code>onExit</code></strong>
+	 *
+	 * @param stopPromise the promise that indicates the completion state of this loader
+	 */
+	void onExit(Promise<Void> stopPromise) throws Exception;
+
+	/**
+	 * Gets called, before the {@link ConfigDeploymentLauncher Launcher} deploys a new
+	 * {@link io.vertx.core.Verticle Verticle}.
+	 * <p>
+	 * Use this event if you want to run steps before a verticle deploys.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution. A failed promise <strong>prevents</strong> the verticle from deploying.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * <strong><code>onBeforeVerticleDeploy</code></strong> ➔
+	 * {@link #onAfterVerticleDeploy(Promise, Deployment) onAfterVerticleDeploy}
+	 *
+	 * @param completePromise the promise that indicates the completion state of this loader
+	 * @param deployment      the deployment which contains the {@link io.vertx.core.Verticle Verticle} that deploys
+	 */
+	void onBeforeVerticleDeploy(Promise<Void> completePromise, Deployment deployment) throws Exception;
+
+	/**
+	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} deploys a new
+	 * {@link io.vertx.core.Verticle Verticle}.
+	 * <p>
+	 * Use this event if you want to run steps after a verticle deploys.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * {@link #onBeforeVerticleDeploy(Promise, Deployment) onBeforeVerticleDeploy} ➔
+	 * <strong><code>onAfterVerticleDeploy</code></strong>
+	 *
+	 * @param completePromise the promise that indicates the completion state of this loader
+	 * @param deployment      the deployment which contains the {@link io.vertx.core.Verticle Verticle} that deploys
+	 */
+	void onAfterVerticleDeploy(Promise<Void> completePromise, Deployment deployment) throws Exception;
+
+	/**
+	 * Gets called, before the {@link ConfigDeploymentLauncher Launcher} un-deploys a running
+	 * {@link io.vertx.core.Verticle Verticle}.
+	 * <p>
+	 * Use this event if you want to run steps before a verticle un-deploys.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution. A failed promise <strong>prevents</strong> the verticle from un-deploying.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * <strong><code>onBeforeVerticleUndeploy</code></strong> ➔
+	 * {@link #onAfterVerticleUndeploy(Promise, Deployment) onAfterVerticleUndeploy}
+	 *
+	 * @param completePromise the promise that indicates the completion state of this loader
+	 * @param deployment      the deployment which contains the {@link io.vertx.core.Verticle Verticle} that un-deploys
+	 */
+	void onBeforeVerticleUndeploy(Promise<Void> completePromise, Deployment deployment) throws Exception;
+
+	/**
+	 * Gets called, after the {@link ConfigDeploymentLauncher Launcher} un-deploys a running
+	 * {@link io.vertx.core.Verticle Verticle}.
+	 * <p>
+	 * Use this event if you want to run steps after a verticle un-deploys.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution. A failed promise <strong>prevents</strong> the verticle from un-deploying.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 * <p>
+	 * <em>Call chain</em>:
+	 * {@link #onBeforeVerticleUndeploy(Promise, Deployment) onBeforeVerticleUndeploy} ➔
+	 * <strong><code>onAfterVerticleUndeploy</code></strong>
+	 *
+	 * @param completePromise the promise that indicates the completion state of this loader
+	 * @param deployment      the deployment which contains the {@link io.vertx.core.Verticle Verticle} that un-deploys
+	 */
+	void onAfterVerticleUndeploy(Promise<Void> completePromise, Deployment deployment) throws Exception;
+
+	/**
+	 * Gets called, when the running {@link io.vertx.core.Vertx Vertx} instance in the
+	 * {@link ConfigDeploymentLauncher Launcher} encounters an uncaught exception.
+	 * <p>
+	 * Use this event if you want to run steps on uncaught exception on the Vertx instance.
+	 * <p>
+	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounter
+	 * an error during execution.
+	 * <p>
+	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
+	 *
+	 * @param completePromise the promise that indicates the completion state of this loader
+	 * @param cause           the cause that the Vertx instances encounters
+	 */
+	void onVertxException(Promise<Void> completePromise, Throwable cause) throws Exception;
+}

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/Loader.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/Loader.java
@@ -259,7 +259,8 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	 * Use this event if you want to run steps before a verticle deploys.
 	 * <p>
 	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
-	 * an error during execution. A failed promise <strong>prevents</strong> the verticle from deploying.
+	 * an error during execution. A failed promise <strong>only prevents</strong> this specific deployment
+	 * from deploying.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
 	 * <p>
@@ -299,7 +300,8 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	 * Use this event if you want to run steps before a verticle un-deploys.
 	 * <p>
 	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
-	 * an error during execution. A failed promise <strong>prevents</strong> the verticle from un-deploying.
+	 * an error during execution. A failed promise <strong>only prevents</strong> this specific deployment
+	 * from un-deploying.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
 	 * <p>
@@ -319,7 +321,7 @@ public interface Loader<T extends LoaderConfiguration> extends DefaultConfigurab
 	 * Use this event if you want to run steps after a verticle un-deploys.
 	 * <p>
 	 * The passed promise should resolve when this loader finishes its execution and fail if the loader encounters
-	 * an error during execution. A failed promise <strong>prevents</strong> the verticle from un-deploying.
+	 * an error during execution.
 	 * <p>
 	 * The launcher calls this event handler. <strong>Don't call it by yourself.</strong>
 	 * <p>

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/LoaderConfiguration.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/LoaderConfiguration.java
@@ -4,7 +4,7 @@ import de.wuespace.telestion.api.message.JsonMessage;
 
 /**
  * The base class for all {@link Loader Loader} configurations.
- * It extends {@link JsonMessage} so all configurations are also valid json classes.
+ * It extends {@link JsonMessage} so all configurations are also valid JSON classes.
  *
  * @author Ludwig Richter (@fussel178)
  */

--- a/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/LoaderConfiguration.java
+++ b/modules/telestion-application/src/main/java/de/wuespace/telestion/application/loader/LoaderConfiguration.java
@@ -1,0 +1,12 @@
+package de.wuespace.telestion.application.loader;
+
+import de.wuespace.telestion.api.message.JsonMessage;
+
+/**
+ * The base class for all {@link Loader Loader} configurations.
+ * It extends {@link JsonMessage} so all configurations are also valid json classes.
+ *
+ * @author Ludwig Richter (@fussel178)
+ */
+public interface LoaderConfiguration extends JsonMessage {
+}


### PR DESCRIPTION
### Stacked Pull Request

This is a stacked pull request. Please wait on pending pull requests that reference on this branch before merging this branch.
Take a look at https://www.michaelagreiler.com/stacked-pull-requests/ for more information.

### Summary <!-- Summarize the content of the pull request in one sentence -->

This PR introduces loaders and deployments to the application module.

### Details <!-- Describe the content of the pull request -->

#### Loaders

A loader is basically a collection of event hooks where some of them can be called during startup or shutdown procedures of launchers or verticles (or other events). The loader interface defines the connection between all implementing loaders so for example launchers using loaders in their startup and shutdown process have a unified structure.

Let's implement a basic loader:

```java
// proof of concept code
public class MyLoader implements Loader {
	public void onAfterVertxStartup(Promise<Void> startPromise) throws Exception {
		logger.info("The Vertx instance has started!");
	}

	// [...]
}
```

As you can see, the `MyLoader` provides an event hook that can be called by a launcher which for example controls a Vert.x instance. The launcher then waits that the Vert.x instance started itself and calls the `onAfterVertxStartup` on all registered loaders.

#### Deployments

A deployment is a representation of a verticle which can be deployed in a Vert.x instance or un-deployed again.
The deployment holds the needed information like the deployment id, the deployment options or the associated Vert.x instance
and provides convenience functions for easy deploy and un-deploy.

Deployments are later used to deploy verticles read from a configuration file.

#### More launcher specializations

This PR adds new launcher types which engage them to control loaders or deployments in their scope.

The added types are:

- the `LoaderLauncher` which controls a list of loaders
- the `DeploymentLauncher` which controls a list of deployments
- and the `ConfigDeploymentLauncher` which combines the functionality of the config and deployment launcher

### Sample project

You can find a sample project that uses the new application structure here:

https://github.com/wuespace/telestion-project-playground/tree/fussel178/feat/application-rewrite/application

### Next steps

This PR belongs to a series of changes which updates the application structure in Telestion.

Read next: https://github.com/wuespace/telestion-core/pull/502
Read previous: https://github.com/wuespace/telestion-core/pull/500

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
