### PR TITLE
Add license and Manifest attributes to published module JARs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,136 @@ subprojects {
                     "--add-opens", "java.management/sun.management=ALL-UNNAMED",
                     "--add-opens", "jdk.management/com.sun.management.internal=ALL-UNNAMED"]
     }
+
+    jar {
+        afterEvaluate {
+            manifest {
+
+                var description = Objects.nonNull(project.description) ? project.description : 'No description'
+                var specTitle = project.extensions.extraProperties.has('prettyName')
+                        ? project.extensions.extraProperties.get('prettyName')
+                        : 'Telestion Module'
+
+                attributes(
+                        'Build-Timestamp': new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
+                        'Created-By': "Gradle ${gradle.gradleVersion}",
+                        'Build-Jdk': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+                        'Build-Jdk-Spec': "${System.properties['java.version']}",
+                        'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}",
+                        'Specification-Title': specTitle,
+                        'Specification-Version': project.version,
+                        'Specification-Vendor': 'WueSpace e.V.',
+                        'Implementation-Title': project.name,
+                        'Implementation-Version': project.version,
+                        'Implementation-Vendor': 'de.wuespace.telestion',
+                        'X-Compile-Target-JDK': gradle.ext.targetCompatibility,
+                        'X-Compile-Source-JDK': gradle.ext.sourceCompatibility,
+                        'Description': description
+                )
+            }
+        }
+    }
+
+    publishing {
+        afterEvaluate {
+            publications {
+                maven(MavenPublication) {
+                    from components.java
+
+                    pom {
+                        name = project.name
+                        description = project.description
+                        url = 'https://telestion.wuespace.de/'
+
+                        licenses {
+                            license {
+                                name = 'MIT License'
+                                url = 'https://opensource.org/licenses/mit-license.php'
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                id = 'jvpichowski'
+                                name = 'Jan von Pichovski'
+                                email = 'janvonpichowski@gmail.com'
+                                url = 'https://github.com/jvpichowski'
+                                organization = 'WüSpace e. V.'
+                                organizationUrl = 'https://www.wuespace.de/'
+                            }
+
+                            developer {
+                                id = 'cb0s'
+                                name = 'Cedric Bös'
+                                email = 'cedric.boes@online.de'
+                                url = 'https://github.com/cb0s'
+                                organization = 'WüSpace e. V.'
+                                organizationUrl = 'https://www.wuespace.de/'
+                            }
+
+                            developer {
+                                id = 'fussel178'
+                                name = 'Ludwig Richter'
+                                email = 'riluzm@posteo.de'
+                                url = 'https://github.com/fussel178'
+                                organization = 'WüSpace e. V.'
+                                organizationUrl = 'https://www.wuespace.de/'
+                            }
+
+                            developer {
+                                id = 'pklaschka'
+                                name = 'Pablo Klaschka'
+                                email = 'contact@pabloklaschka.de'
+                                url = 'https://github.com/pklaschka'
+                                organization = 'WüSpace e. V.'
+                                organizationUrl = 'https://www.wuespace.de/'
+                            }
+                        }
+
+                        scm {
+                            connection = 'scm:git:git://github.com/wuespace/telestion-core.git'
+                            developerConnection = 'scm:git:ssh://git@github.com:wuespace/telestion-core.git'
+                            url = 'https://github.com/wuespace/telestion-core/tree/main'
+                        }
+                    }
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+
+                credentials {
+                    username = System.getenv('OSSRH_USERNAME')
+                    password = System.getenv('OSSRH_PASSWORD')
+                }
+            }
+
+            maven {
+                name = "GitHubPackages"
+                url = "https://maven.pkg.github.com/wuespace/telestion-core"
+                credentials {
+                    username = System.getenv("GITHUB_ACTOR")
+                    password = System.getenv("GITHUB_TOKEN")
+                }
+            }
+        }
+    }
+
+    signing {
+        afterEvaluate {
+            required { gradle.forceSign || gradle.taskGraph.hasTask('publish') }
+            // get key + key-id + password
+            def signingKeyId = findProperty('signingKeyId') as String
+            def signingKey = findProperty('signingKey') as String
+            def signingPassword = findProperty('signingPassword') as String
+            // decrypt key
+            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+            // sign
+            sign publishing.publications.maven
+        }
+    }
 }
 
 task alljavadoc(type: Javadoc) {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ subprojects {
     }
 
     jar {
+        metaInf {
+            from("$projectDir/../../LICENSE")
+        }
+
         afterEvaluate {
             manifest {
 

--- a/modules/telestion-api/build.gradle
+++ b/modules/telestion-api/build.gradle
@@ -12,101 +12,11 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 
-publishing {
-    publications {
-        maven(MavenPublication) {
-            from components.java
-
-            pom {
-                name = 'Telestion API'
-                description = 'The essential components for a Telestion Project Application'
-                url = 'https://telestion.wuespace.de/'
-
-                licenses {
-                    license {
-                        name = 'MIT License'
-                        url = 'https://opensource.org/licenses/mit-license.php'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'jvpichowski'
-                        name = 'Jan von Pichovski'
-                        email = 'janvonpichowski@gmail.com'
-                        url = 'https://github.com/jvpichowski'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'cb0s'
-                        name = 'Cedric Bös'
-                        email = 'cedric.boes@online.de'
-                        url = 'https://github.com/cb0s'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'fussel178'
-                        name = 'Ludwig Richter'
-                        email = 'riluzm@posteo.de'
-                        url = 'https://github.com/fussel178'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'pklaschka'
-                        name = 'Pablo Klaschka'
-                        email = 'contact@pabloklaschka.de'
-                        url = 'https://github.com/pklaschka'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/wuespace/telestion-core.git'
-                    developerConnection = 'scm:git:ssh://git@github.com:wuespace/telestion-core.git'
-                    url = 'https://github.com/wuespace/telestion-core/tree/main'
-                }
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-
-            credentials {
-                username = System.getenv('OSSRH_USERNAME')
-                password = System.getenv('OSSRH_PASSWORD')
-            }
-        }
-
-        maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/wuespace/telestion-core"
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
+ext {
+    prettyName = 'Telestion API'
 }
 
-signing {
-    required { gradle.forceSign || gradle.taskGraph.hasTask('publish') }
-    // get key + key-id + password
-    def signingKeyId = findProperty('signingKeyId') as String
-    def signingKey = findProperty('signingKey') as String
-    def signingPassword = findProperty('signingPassword') as String
-    // decrypt key
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    // sign
-    sign publishing.publications.maven
-}
+description = 'The essential components for a Telestion Project Application'
 
 dependencies {
     implementation 'com.google.guava:guava:31.0.1-jre'

--- a/modules/telestion-application/build.gradle
+++ b/modules/telestion-application/build.gradle
@@ -12,101 +12,11 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 
-publishing {
-    publications {
-        maven(MavenPublication) {
-            from components.java
-
-            pom {
-                name = 'Telestion Application'
-                description = 'The starting point of a Telestion Project Application'
-                url = 'https://telestion.wuespace.de/'
-
-                licenses {
-                    license {
-                        name = 'MIT License'
-                        url = 'https://opensource.org/licenses/mit-license.php'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'jvpichowski'
-                        name = 'Jan von Pichovski'
-                        email = 'janvonpichowski@gmail.com'
-                        url = 'https://github.com/jvpichowski'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'cb0s'
-                        name = 'Cedric Bös'
-                        email = 'cedric.boes@online.de'
-                        url = 'https://github.com/cb0s'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'fussel178'
-                        name = 'Ludwig Richter'
-                        email = 'riluzm@posteo.de'
-                        url = 'https://github.com/fussel178'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'pklaschka'
-                        name = 'Pablo Klaschka'
-                        email = 'contact@pabloklaschka.de'
-                        url = 'https://github.com/pklaschka'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/wuespace/telestion-core.git'
-                    developerConnection = 'scm:git:ssh://git@github.com:wuespace/telestion-core.git'
-                    url = 'https://github.com/wuespace/telestion-core/tree/main'
-                }
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-
-            credentials {
-                username = System.getenv('OSSRH_USERNAME')
-                password = System.getenv('OSSRH_PASSWORD')
-            }
-        }
-
-        maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/wuespace/telestion-core"
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
+ext {
+    prettyName = 'Telestion Application'
 }
 
-signing {
-    required { gradle.forceSign || gradle.taskGraph.hasTask('publish') }
-    // get key + key-id + password
-    def signingKeyId = findProperty('signingKeyId') as String
-    def signingKey = findProperty('signingKey') as String
-    def signingPassword = findProperty('signingPassword') as String
-    // decrypt key
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    // sign
-    sign publishing.publications.maven
-}
+description = 'The starting point of a Telestion Project Application'
 
 dependencies {
     implementation project(':modules:telestion-services')

--- a/modules/telestion-examples/build.gradle
+++ b/modules/telestion-examples/build.gradle
@@ -12,101 +12,11 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 
-publishing {
-    publications {
-        maven(MavenPublication) {
-            from components.java
-
-            pom {
-                name = 'Telestion Examples'
-                description = 'Examples describing different use cases of Telestion'
-                url = 'https://telestion.wuespace.de/'
-
-                licenses {
-                    license {
-                        name = 'MIT License'
-                        url = 'https://opensource.org/licenses/mit-license.php'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'jvpichowski'
-                        name = 'Jan von Pichovski'
-                        email = 'janvonpichowski@gmail.com'
-                        url = 'https://github.com/jvpichowski'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'cb0s'
-                        name = 'Cedric Bös'
-                        email = 'cedric.boes@online.de'
-                        url = 'https://github.com/cb0s'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'fussel178'
-                        name = 'Ludwig Richter'
-                        email = 'riluzm@posteo.de'
-                        url = 'https://github.com/fussel178'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'pklaschka'
-                        name = 'Pablo Klaschka'
-                        email = 'contact@pabloklaschka.de'
-                        url = 'https://github.com/pklaschka'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/wuespace/telestion-core.git'
-                    developerConnection = 'scm:git:ssh://git@github.com:wuespace/telestion-core.git'
-                    url = 'https://github.com/wuespace/telestion-core/tree/main'
-                }
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-
-            credentials {
-                username = System.getenv('OSSRH_USERNAME')
-                password = System.getenv('OSSRH_PASSWORD')
-            }
-        }
-
-        maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/wuespace/telestion-core"
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
+ext {
+    prettyName = 'Telestion Examples'
 }
 
-signing {
-    required { gradle.forceSign || gradle.taskGraph.hasTask('publish') }
-    // get key + key-id + password
-    def signingKeyId = findProperty('signingKeyId') as String
-    def signingKey = findProperty('signingKey') as String
-    def signingPassword = findProperty('signingPassword') as String
-    // decrypt key
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    // sign
-    sign publishing.publications.maven
-}
+description = 'Examples describing different use cases of Telestion'
 
 dependencies {
     implementation project(':modules:telestion-api')

--- a/modules/telestion-services/build.gradle
+++ b/modules/telestion-services/build.gradle
@@ -12,110 +12,11 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 
-publishing {
-    publications {
-        maven(MavenPublication) {
-            from components.java
-
-            pom {
-                name = 'Telestion Services'
-                description = 'Services and service components that are re-usable in any Telestion Project Application'
-                url = 'https://telestion.wuespace.de/'
-
-                licenses {
-                    license {
-                        name = 'MIT License'
-                        url = 'https://opensource.org/licenses/mit-license.php'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'jvpichowski'
-                        name = 'Jan von Pichovski'
-                        email = 'janvonpichowski@gmail.com'
-                        url = 'https://github.com/jvpichowski'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'cb0s'
-                        name = 'Cedric Bös'
-                        email = 'cedric.boes@online.de'
-                        url = 'https://github.com/cb0s'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'fussel178'
-                        name = 'Ludwig Richter'
-                        email = 'riluzm@posteo.de'
-                        url = 'https://github.com/fussel178'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'pklaschka'
-                        name = 'Pablo Klaschka'
-                        email = 'contact@pabloklaschka.de'
-                        url = 'https://github.com/pklaschka'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-
-                    developer {
-                        id = 'jantischhoefer'
-                        name = 'Jan Tischhöfer'
-                        email = 'jan.tischhoefer@gmail.com'
-                        url = 'https://github.com/jantischhoefer'
-                        organization = 'WüSpace e. V.'
-                        organizationUrl = 'https://www.wuespace.de/'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git://github.com/wuespace/telestion-core.git'
-                    developerConnection = 'scm:git:ssh://git@github.com:wuespace/telestion-core.git'
-                    url = 'https://github.com/wuespace/telestion-core/tree/main'
-                }
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            url "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-
-            credentials {
-                username = System.getenv('OSSRH_USERNAME')
-                password = System.getenv('OSSRH_PASSWORD')
-            }
-        }
-
-        maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/wuespace/telestion-core"
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
+ext {
+    prettyName = 'Telestion Services'
 }
 
-signing {
-    required { gradle.forceSign || gradle.taskGraph.hasTask('publish') }
-    // get key + key-id + password
-    def signingKeyId = findProperty('signingKeyId') as String
-    def signingKey = findProperty('signingKey') as String
-    def signingPassword = findProperty('signingPassword') as String
-    // decrypt key
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    // sign
-    sign publishing.publications.maven
-}
+description = 'Services and service components that are re-usable in any Telestion Project Application'
 
 dependencies {
     // implementation name: 'engine'


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

Add license and Manifest attributes to published module JARs.

### Details <!-- Describe the content of the pull request -->

During development I encountered the method `SomeClass.getPackage().getSpecificationVersion()` which returns the current version of the package that contains the called class.

The method looks in the packaged `META-INF/MANIFEST:MF` file for this property. But our library modules don't have this property. :thinking: 

Lets configure gradle to add version, vendor and all the other stuff to the `MANIFEST.MF` before publishing.

Additionally, lets clean up some of the redundant configuration code like the `publishing` or `signing` closures.

And the published modules don't contain our `LICENSE` file. Lets fix that.

I don't like gradle.

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
