### PR TITLE
Pre-defined Verticle Configuration types

### DIFF
--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/GenericConfiguration.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/GenericConfiguration.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  *
  * @author Pablo Klaschka (@pklaschka), Ludwig Richter (@fussel178)
  * @see TelestionVerticle#getConfig()
- * @deprecated Use {@link UntypedConfiguration} instead.
+ * @deprecated Use {@link UntypedConfiguration} to indicate generic, untyped configuration or {@link NoConfiguration}
+ * to indicate no configuration options instead. To build your own typed configuration options, implement
+ * {@link TelestionConfiguration}.
  */
 @Deprecated(since = "0.8.0")
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/GenericConfiguration.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/GenericConfiguration.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  *
  * @author Pablo Klaschka (@pklaschka), Ludwig Richter (@fussel178)
  * @see TelestionVerticle#getConfig()
+ * @deprecated Use {@link UntypedConfiguration} instead.
  */
+@Deprecated(since = "0.8.0")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record GenericConfiguration() implements TelestionConfiguration {
 }

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/NoConfiguration.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/NoConfiguration.java
@@ -1,0 +1,14 @@
+package de.wuespace.telestion.api.verticle;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * The type of configuration for a {@link TelestionVerticle} that you use
+ * to indicate that the verticle doesn't accept any configuration.
+ *
+ * @author Pablo Klaschka (@pklaschka), Cedric Boes (@cb0s), Ludwig Richter (@fussel178)
+ * @see TelestionVerticle#getConfig()
+ */
+@JsonIgnoreProperties(ignoreUnknown = false)
+public record NoConfiguration() implements TelestionConfiguration {
+}

--- a/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/UntypedConfiguration.java
+++ b/modules/telestion-api/src/main/java/de/wuespace/telestion/api/verticle/UntypedConfiguration.java
@@ -1,0 +1,14 @@
+package de.wuespace.telestion.api.verticle;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * The type of configuration for a {@link TelestionVerticle} that you use
+ * to indicate that the verticle does not have a strictly typed configuration.
+ *
+ * @author Pablo Klaschka (@pklaschka), Cedric Boes (@cb0s), Ludwig Richter (@fussel178)
+ * @see TelestionVerticle#getConfig()
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UntypedConfiguration() implements TelestionConfiguration {
+}


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

Add more Verticle Configuration types.

### Details <!-- Describe the content of the pull request -->

As discussed in #490, lets introduce 2 new types:

- `NoConfiguration` to indicate that the verticle doesn't accept any configuration
- `UntypedConfiguration` to indicate that the verticle doesn't have a strictly typed configuration

And deprecate `GenericConfiguration`.

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

- Fixes #490 

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
