### PR TITLE
feat(api): Ideas/examples for a possible optional JsonType API

### DIFF
--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt1/Opt1Example.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt1/Opt1Example.java
@@ -1,0 +1,13 @@
+package de.wuespace.telestion.api.message.optionalprops.opt1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Opt1Example(
+		@JsonProperty @OptionalJsonProperty(defaultString = "foo") String foo,
+		// We can even give global default parameters by inferring them into @OptionalJsonProperty
+		@JsonProperty @OptionalJsonProperty int bar,
+		@JsonProperty
+		boolean extraBar,	// Not everything must be optional
+		@JsonProperty @OptionalJsonProperty(defaultChar = 'F')
+		char extraFoo) {
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt1/OptionalJsonProperty.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt1/OptionalJsonProperty.java
@@ -1,0 +1,13 @@
+package de.wuespace.telestion.api.message.optionalprops.opt1;
+
+public @interface OptionalJsonProperty {
+	byte defaultByte() default -1;
+	short defaultShort() default -1;
+	int defaultInt() default -1;
+	long defaultLong() default -1;
+	float defaultFloat() default -1.0f;
+	double defaultDouble() default -1.0;
+	char defaultChar() default 0x0;
+	boolean defaultBool() default false;
+	String defaultString() default "";
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/Opt2Example.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/Opt2Example.java
@@ -1,0 +1,13 @@
+package de.wuespace.telestion.api.message.optionalprops.opt2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Opt2Example(@JsonProperty @OptionalString(defaultString = "foo") String s,
+						  @JsonProperty @OptionalBool(defaultBool = false) boolean bool,
+						  @JsonProperty @OptionalByte(defaultByte = 127) byte b,
+						  @JsonProperty @OptionalInt(defaultInt = -1) int i) {
+	/*
+	 * Note that this implementation could also be improved by adding global default parameters to each of the
+	 * annotations as it was shown by example 1.
+	 */
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/OptionalBool.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/OptionalBool.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt2;
+
+public @interface OptionalBool {
+	boolean defaultBool();
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/OptionalByte.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/OptionalByte.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt2;
+
+public @interface OptionalByte {
+	byte defaultByte();
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/OptionalInt.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/OptionalInt.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt2;
+
+public @interface OptionalInt {
+	int defaultInt();
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/OptionalString.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/OptionalString.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt2;
+
+public @interface OptionalString {
+	String defaultString();
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/z_andSoOn.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt2/z_andSoOn.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt2;
+
+public @interface z_andSoOn {
+	String andAnAnnotationForEveryOtherNotMentionedDatatype();
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/Opt3Example.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/Opt3Example.java
@@ -1,0 +1,13 @@
+package de.wuespace.telestion.api.message.optionalprops.opt3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Opt3Example(@JsonProperty @OptionalBool(defaultBool = true) boolean bool,
+						  @JsonProperty @OptionalFloatingPoint(defaultFloat = 0.0) float f,
+						  @JsonProperty @OptionalFloatingPoint(defaultFloat = 0.1) double d,
+						  @JsonProperty @OptionalInteger(defaultInteger = 10) long l,
+						  @JsonProperty @OptionalInteger(defaultInteger = -1204) int i,
+						  @JsonProperty @OptionalString(defaultString = "cb0s Was Here :D") String s,
+						  // It might be beneficial to add one more annotation for chars
+						  @JsonProperty @OptionalInteger(defaultInteger = 65) char c) {
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/OptionalBool.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/OptionalBool.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt3;
+
+public @interface OptionalBool {
+	boolean defaultBool();
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/OptionalFloatingPoint.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/OptionalFloatingPoint.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt3;
+
+public @interface OptionalFloatingPoint {
+	double defaultFloat();
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/OptionalInteger.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/OptionalInteger.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt3;
+
+public @interface OptionalInteger {
+	long defaultInteger();
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/OptionalString.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt3/OptionalString.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt3;
+
+public @interface OptionalString {
+	String defaultString();
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt4/Opt4Example.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt4/Opt4Example.java
@@ -1,0 +1,12 @@
+package de.wuespace.telestion.api.message.optionalprops.opt4;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Opt4Example(@JsonProperty @OptionalJsonProperty(defaultVal = "34.1") float f,
+						  @JsonProperty @OptionalJsonProperty(defaultVal = "123") int i,
+						  @JsonProperty @OptionalJsonProperty(defaultVal = "This is a proper String") String s) {
+	/*
+	 * With this solution, the config loader would automatically parse those values to the designated data types.
+	 * This works around the problem imposed by the static type system by java, but could be notably slower.
+	 */
+}

--- a/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt4/OptionalJsonProperty.java
+++ b/telestion-api/src/main/java/de/wuespace/telestion/api/message/optionalprops/opt4/OptionalJsonProperty.java
@@ -1,0 +1,5 @@
+package de.wuespace.telestion.api.message.optionalprops.opt4;
+
+public @interface OptionalJsonProperty {
+	String defaultVal();
+}


### PR DESCRIPTION
  # Optional JsonProperties for the Configurations of the Telestion Verticles
  
  ## Problem
  
  As soon as verticles get complexer, optional JsonProperties for the defining Configuration are helpful to reduce the work by the configurating party - the end user - who expectedly has little to no experience at all with the Telestion Ecosystem. Therefore, these should be deemed a highly important role, making the project a lot more appealing to annoyed software developers, being woken up at 9 am (very early for a developer) to fix the missing parts of the configurations... 😆 
  
  ## Current state
  
  At the moment, there is no special support for this feature apart from the native support out of the box from the Jackson Library or additional libraries. Unfortunately, the Jackson API does not easily support default parameters for inferring other than for documenation reasons as the Java Type System and its stubborness makes a good design difficult (or even impossible) and no possible solution. To be fair, there is one possibility to add those to the existing system. One has to add an additional constructor without one of the fields, which does not only stack up with more and more record parameters (problem 1), but also imposes problems with parameters of the same type in one class (problem 2). An example showcasing both of those problems is seen below. We want to give Default parameters to every parameter:
  
  ```java
  public record Foo(String param1, int param2, String param3) {
      // No parameters
      public Foo() {
          this("param1Foo", 42, "anotherFoo");
      }
      // Only param 1
      public Foo(String param1) {
          this(param1, 43, "anotherFoo");
      }
      // Only param 3
      public Foo(String param3) {  // <----- actually does not work as this constructor already exists for param 1 -> problem 2
          this("param1Foo", 42, param3);
      }
  
     // ... -> we need 4 contructors more to cover every edge case (one for param 2 alone and then 3 more for the different pairs)
  }
  ```

Note that with this solution and the massive amounts of equal implementations also small mistakes as shown in the constructor for `String param1` lead to fast bugs in the development of more complex verticles. Here, obviously the 43 should be a 42. This obviously can also be targetted by constant static variables, but imho this is still a bad style of implementation if you need an extra mechanic to fix a problem that shouldn't even exist in the first place.
  
  ## Implementation Suggestions
  
  In all cases, the manual overhead of adding default information to each of the Record values should be as low as possible. Therefore, an annotation-based approach is suggested which complements the existing `@JsonProperty` from Jackson. As seen in the examples, the Annotations are only added additionally to the fields. In a future release, it could also be thought of combining those additional Annotations with the JsonProperty into one Property, reducing the overhead even further. In the background a manual ObjectMapper (already provided by the Jackson API) could be used, which could work hand in hand with the proposed new Launcher API by @fussel178 - the registering would take place in this new Launcher API at the start of the Application. Currently, up to this point, the registering alternatively would take place in the Telestion class in the application package.
  
  ### Details about the implementation 
  
  These 4 suggestions show possible implementations for the support of OptionalJsonProperty without relying on a big number of manual constructors as suggested by the creators of Jackson. Consequently, none of those implementations are working at this point and should only be seen as examples of how an API could look like, especially because the rest of the API would be hidden, and only the annotation are used by the users of the Telestion System.
  
  ## Meta information about this PR
  
  ### Related links <!-- Related resources, issues and pull requests -->
  
  As far as I know, no current Issue is targetting this problem.
  
  ### CLA
  
  - [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
  
  
  -----
  
  I would love some feedback and an open discussion about this problem! 👀 
